### PR TITLE
refactor: clean up verify error handling

### DIFF
--- a/src/utils/signing.ts
+++ b/src/utils/signing.ts
@@ -92,14 +92,17 @@ export function verifyMessage(
       // In @noble/curves v2, verify() accepts Uint8Array signature directly
       const signatureBytes = hexToBytes(signature)
       return secp256k1.verify(signatureBytes, messageBytes, keyPublicBytes)
-    } catch (error) {
-      console.error('Verification error:', error)
+    } catch {
       return false
     }
   } 
   else if (curve === 'ed25519') {
     // Ed25519 doesn't typically prehash the message
-    return ed25519.verify(hexToBytes(signature), messageBytes, keyPublicBytes)
+    try {
+      return ed25519.verify(hexToBytes(signature), messageBytes, keyPublicBytes)
+    } catch {
+      return false
+    }
   }
   
   throw new Error(`Unsupported curve: ${curve}`)


### PR DESCRIPTION
## Summary

`verifyMessage` in `signing.ts` was calling `console.error` when secp256k1 verification threw, which leaks into consumer output. Libraries shouldn't write to stderr — that's the caller's job.

While there, wrapped the ed25519 path in try/catch too. It was the only verify branch that could throw on malformed inputs instead of returning false.

Closes #4

## Changes

- Removed `console.error` from secp256k1 verify catch block
- Added try/catch around ed25519 verify for consistent error handling
- Both curves now silently return `false` on invalid inputs

## Testing

All 185 existing tests pass. The "wrong public key" and "wrong message" test cases already cover the error paths.