### PR TITLE
fix(address): correct P2SH redeem script buffer size

### DIFF
--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -103,7 +103,7 @@ export function generateAddressP2SH(keyPublic: string, options: OptionsAddressP2
   const hashPubKey = hash160(bytesKeyPublic);
 
   // Create redeem script (simplification, real P2SH would be more complex)
-  const redeemScript = new Uint8Array(hashPubKey.length + 3);
+  const redeemScript = new Uint8Array(hashPubKey.length + 2);
   redeemScript[0] = 0x00; // OP_0
   redeemScript[1] = 0x14; // 20 bytes length
   redeemScript.set(hashPubKey, 2);

--- a/test/utils/address.test.ts
+++ b/test/utils/address.test.ts
@@ -52,6 +52,13 @@ describe("Address utilities", () => {
   });
 
   describe("P2SH addresses", () => {
+    it("should generate correct P2SH address for known public key", () => {
+      // Generator point G - known P2SH-P2WPKH address
+      const generatorKey = "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798";
+      const address = generateAddressP2SH(generatorKey, { bytesVersion: 0x05 });
+      expect(address).toBe("3JvL6Ymt8MVWiCNHC7oWU6nLeHNJKLZGLN");
+    });
+
     it("should generate a valid P2SH address with correct version byte", () => {
       const address = generateAddressP2SH(testPublicKey, { bytesVersion: 0x05 });
 


### PR DESCRIPTION
The P2SH redeem script buffer was allocated one byte too large (`hashPubKey.length + 3` instead of `+ 2`). Only 22 bytes get written - `OP_0`, the push length byte, and the 20-byte hash - but 23 were allocated. That trailing zero byte feeds into the script hash, so every P2SH address came out wrong.

Added a reference vector test against the known P2SH-P2WPKH address for the generator point G to catch regressions.

Closes #8