### PR TITLE
fix(evm): correct hashWithPreamble for Uint8Array input

### DIFF
--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -126,11 +126,10 @@ export function validateAddress(address: string): boolean {
 function hashWithPreamble(message: string | Uint8Array): Uint8Array {
   const preamble = "\u0019Ethereum Signed Message:\n";
   const messageBytes = typeof message === "string" ? new TextEncoder().encode(message) : message;
-  const fullMessage = new TextEncoder().encode(
-    preamble +
-      messageBytes.length.toString() +
-      (typeof message === "string" ? message : bytesToHex(message)),
-  );
+  const preambleBytes = new TextEncoder().encode(preamble + messageBytes.length.toString());
+  const fullMessage = new Uint8Array(preambleBytes.length + messageBytes.length);
+  fullMessage.set(preambleBytes);
+  fullMessage.set(messageBytes, preambleBytes.length);
   return keccak_256(fullMessage);
 }
 

--- a/test/utils/signing.test.ts
+++ b/test/utils/signing.test.ts
@@ -96,6 +96,25 @@ describe("Signing utilities", () => {
 
       expect(evmSig).not.toBe(basicSig);
     });
+
+    it("should produce identical hash for string and equivalent Uint8Array", () => {
+      const messageString = "Hello";
+      const messageBytes = new TextEncoder().encode(messageString);
+
+      const sigFromString = evmSignMessage(messageString, secp256k1TestPrivateKey);
+      const sigFromBytes = evmSignMessage(messageBytes, secp256k1TestPrivateKey);
+
+      expect(sigFromBytes).toBe(sigFromString);
+    });
+
+    it("should sign Uint8Array messages", () => {
+      const messageBytes = new TextEncoder().encode(testMessage);
+
+      const signature = evmSignMessage(messageBytes, secp256k1TestPrivateKey);
+
+      expect(signature).toBeTypeOf("string");
+      expect(hexToBytes(signature).length).toBeGreaterThanOrEqual(64);
+    });
   });
 
   describe("Ed25519 specific signing", () => {


### PR DESCRIPTION
`hashWithPreamble` built the preambled message by string concatenation - fine for string input, broken for `Uint8Array`. A binary message like `[0x01, 0x02, 0x03]` got hex-encoded to `"010203"` (6 chars) while the length prefix still said `3`, so the keccak256 hash was completely wrong.

The fix builds the full message by concatenating byte arrays directly. String input still takes the same path (TextEncoder gives the same bytes), so existing behavior is unchanged.

Two new tests: one verifies that string and equivalent Uint8Array produce the same signature, the other exercises the Uint8Array signing path.

Closes #7