### PR TITLE
fix(bitcoin): use Bitcoin message preamble instead of Ethereum's

### DIFF
--- a/src/blockchains/bitcoin.ts
+++ b/src/blockchains/bitcoin.ts
@@ -7,8 +7,32 @@ import {
   generateAddressSegWit,
   validateAddressSegWit,
 } from "../utils/address";
-import { evmSignMessage, evmVerifyMessage } from "../utils/evm";
+import { signMessage as genericSignMessage, verifyMessage as genericVerifyMessage } from "../utils/signing";
+import { sha256 } from "@noble/hashes/sha2.js";
 import type { Curve, Options, BlockchainImplementation, KeyOptions } from "../types";
+
+/**
+ * Encode a number as a Bitcoin compact size (varint)
+ */
+function encodeCompactSize(n: number): Uint8Array {
+  if (n < 0xfd) {
+    return new Uint8Array([n]);
+  }
+  if (n <= 0xffff) {
+    const buf = new Uint8Array(3);
+    buf[0] = 0xfd;
+    buf[1] = n & 0xff;
+    buf[2] = (n >> 8) & 0xff;
+    return buf;
+  }
+  const buf = new Uint8Array(5);
+  buf[0] = 0xfe;
+  buf[1] = n & 0xff;
+  buf[2] = (n >> 8) & 0xff;
+  buf[3] = (n >> 16) & 0xff;
+  buf[4] = (n >> 24) & 0xff;
+  return buf;
+}
 
 // Define network parameters interface
 type NetworkParams = {
@@ -140,7 +164,26 @@ export default function bitcoin(options?: Options) {
   }
 
   /**
-   * Signs a message using secp256k1 for Bitcoin
+   * Hashes a message with Bitcoin's message preamble using double SHA-256
+   * Format: varint(24) + "Bitcoin Signed Message:\n" + varint(msgLen) + message
+   *
+   * @param message - The message to hash
+   * @returns The double SHA-256 hash of the prefixed message
+   */
+  function hashWithBitcoinPreamble(message: string | Uint8Array): Uint8Array {
+    const preamble = "\u0018Bitcoin Signed Message:\n";
+    const messageBytes = typeof message === "string" ? new TextEncoder().encode(message) : message;
+    const varint = encodeCompactSize(messageBytes.length);
+    const preambleBytes = new TextEncoder().encode(preamble);
+    const fullMessage = new Uint8Array(preambleBytes.length + varint.length + messageBytes.length);
+    fullMessage.set(preambleBytes);
+    fullMessage.set(varint, preambleBytes.length);
+    fullMessage.set(messageBytes, preambleBytes.length + varint.length);
+    return sha256(sha256(fullMessage));
+  }
+
+  /**
+   * Signs a message using secp256k1 with Bitcoin's message preamble
    *
    * @param message - The message to sign
    * @param keyPrivate - The private key
@@ -152,7 +195,12 @@ export default function bitcoin(options?: Options) {
     keyPrivate: string,
     options?: KeyOptions,
   ): string {
-    return evmSignMessage(message, keyPrivate, options);
+    const hash = hashWithBitcoinPreamble(message);
+    return genericSignMessage(hash, keyPrivate, {
+      curve: "secp256k1",
+      hash: false,
+      ...options,
+    });
   }
 
   /**
@@ -170,7 +218,16 @@ export default function bitcoin(options?: Options) {
     keyPublic: string,
     options?: KeyOptions,
   ): boolean {
-    return evmVerifyMessage(message, signature, keyPublic, options);
+    const hash = hashWithBitcoinPreamble(message);
+    try {
+      return genericVerifyMessage(hash, signature, keyPublic, {
+        curve: "secp256k1",
+        hash: false,
+        ...options,
+      });
+    } catch {
+      return false;
+    }
   }
 
   return {

--- a/src/blockchains/bitcoin.ts
+++ b/src/blockchains/bitcoin.ts
@@ -200,9 +200,9 @@ export default function bitcoin(options?: Options) {
   ): string {
     const hash = hashWithBitcoinPreamble(message);
     return genericSignMessage(hash, keyPrivate, {
+      ...options,
       curve: "secp256k1",
       hash: false,
-      ...options,
     });
   }
 
@@ -224,9 +224,9 @@ export default function bitcoin(options?: Options) {
     const hash = hashWithBitcoinPreamble(message);
     try {
       return genericVerifyMessage(hash, signature, keyPublic, {
+        ...options,
         curve: "secp256k1",
         hash: false,
-        ...options,
       });
     } catch {
       return false;

--- a/src/blockchains/bitcoin.ts
+++ b/src/blockchains/bitcoin.ts
@@ -7,7 +7,10 @@ import {
   generateAddressSegWit,
   validateAddressSegWit,
 } from "../utils/address";
-import { signMessage as genericSignMessage, verifyMessage as genericVerifyMessage } from "../utils/signing";
+import {
+  signMessage as genericSignMessage,
+  verifyMessage as genericVerifyMessage,
+} from "../utils/signing";
 import { sha256 } from "@noble/hashes/sha2.js";
 import type { Curve, Options, BlockchainImplementation, KeyOptions } from "../types";
 

--- a/test/blockchains/bitcoin.test.ts
+++ b/test/blockchains/bitcoin.test.ts
@@ -254,6 +254,29 @@ describe("Bitcoin blockchain", () => {
     });
   });
 
+  describe("Message signing", () => {
+    it("should sign a message and return a hex string", () => {
+      const wallet = blockchain.generateWallet();
+      const signature = blockchain.signMessage("Test message", wallet.keys.private);
+
+      expect(signature).toBeTypeOf("string");
+      expect(signature).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it("should produce different signatures than EVM for the same key and message", async () => {
+      const { default: ethereum } = await import("../../src/blockchains/ethereum");
+      const ethBlockchain = useBlockchain(ethereum());
+
+      const wallet = blockchain.generateWallet();
+      const message = "Test message";
+
+      const btcSig = blockchain.signMessage(message, wallet.keys.private);
+      const ethSig = ethBlockchain.signMessage(message, wallet.keys.private);
+
+      expect(btcSig).not.toBe(ethSig);
+    });
+  });
+
   describe("Testnet addresses", () => {
     // Create bitcoin blockchain with testnet network option
     const options: Options = { network: "testnet" };


### PR DESCRIPTION
Bitcoin's signMessage was delegating to evmSignMessage, which means every Bitcoin signature got hashed with Ethereum's preamble ("\x19Ethereum Signed Message:\n" + keccak256). The resulting signatures were valid secp256k1, but no Bitcoin wallet or explorer would accept them.

Replaced with a proper Bitcoin Core-compatible implementation: "\x18Bitcoin Signed Message:\n" preamble, compact size varint length encoding, and double SHA-256 hashing. The EVM import is gone entirely from bitcoin.ts now.

Tests confirm Bitcoin and Ethereum produce different signatures for the same key and message.

Closes #6