### PR TITLE
refactor!: use abstract blockchain classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ TypeScript library providing a unified interface for key generation, address der
 ubichain/
 ├── src/
 │   ├── index.ts            # Public API surface (re-exports only)
-│   ├── blockchain.ts        # useBlockchain() wrapper - adds convenience methods
+│   ├── blockchain.ts        # AbstractBlockchain base + useBlockchain() identity helper
 │   ├── types.ts             # All shared types (Blockchain, Keys, Wallet, etc.)
 │   ├── _blockchains.ts      # Lazy-loading registry with double-call pattern
-│   ├── blockchains/         # One factory per chain (see blockchains/AGENTS.md)
+│   ├── blockchains/         # One concrete class per chain (see blockchains/AGENTS.md)
 │   └── utils/               # Shared crypto utilities (see utils/AGENTS.md)
 ├── test/                    # Mirrors src/ structure exactly
 │   ├── fixtures.ts          # Shared test vectors (secp256k1, ed25519, bip39, addresses)
@@ -30,24 +30,24 @@ ubichain/
 
 ## WHERE TO LOOK
 
-| Task               | Location                                                                          | Notes                                              |
-| ------------------ | --------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Add new blockchain | `src/blockchains/` + `src/_blockchains.ts`                                        | Factory pattern, register in lazy loader           |
-| Add address format | `src/utils/address.ts`                                                            | Shared across chains (legacy, segwit, hex, base58) |
-| Add EVM chain      | `src/utils/evm.ts` → `createEVMBlockchain()`                                      | 3-line file, reuses factory                        |
-| Fix signing        | `src/utils/signing.ts` (generic) or `evm.ts`/`ed25519-chains.ts` (chain-specific) | EVM uses preamble hash, ed25519 signs raw          |
-| Change public API  | `src/index.ts`                                                                    | Re-exports only, never add logic here              |
-| Add BIP/derivation | `src/utils/bip32/`, `bip39/`, `bip44/`, `slip10/`                                 | Subdirs with index.ts                              |
-| Write tests        | `test/` mirroring `src/` path                                                     | Use fixtures from `test/fixtures.ts`               |
-| Integration test   | `test-integration/`                                                               | Separate pnpm package, manual execution            |
-| Run demos          | `playground/*.ts`                                                                 | Execute via `pnpm playground <file>`               |
+| Task               | Location                                                                          | Notes                                                      |
+| ------------------ | --------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Add new blockchain | `src/blockchains/` + `src/_blockchains.ts`                                        | Extend the appropriate base class, register in lazy loader |
+| Add address format | `src/utils/address.ts`                                                            | Shared across chains (legacy, segwit, hex, base58)         |
+| Add EVM chain      | `src/utils/evm.ts` → `AbstractEVMBlockchain`                                      | Minimal subclass with `name` and `bip44`                   |
+| Fix signing        | `src/utils/signing.ts` (generic) or `evm.ts`/`ed25519-chains.ts` (chain-specific) | EVM uses preamble hash, ed25519 signs raw                  |
+| Change public API  | `src/index.ts`                                                                    | Re-exports only, never add logic here                      |
+| Add BIP/derivation | `src/utils/bip32/`, `bip39/`, `bip44/`, `slip10/`                                 | Subdirs with index.ts                                      |
+| Write tests        | `test/` mirroring `src/` path                                                     | Use fixtures from `test/fixtures.ts`                       |
+| Integration test   | `test-integration/`                                                               | Separate pnpm package, manual execution                    |
+| Run demos          | `playground/*.ts`                                                                 | Execute via `pnpm playground <file>`                       |
 
 ## CONVENTIONS
 
 - **All crypto from @noble/@scure** - never import raw crypto from Node or other libs
-- **Factory pattern** - every blockchain exports `default function name(options?: Options): BlockchainImplementation`
-- **`satisfies BlockchainImplementation`** - every factory return uses this assertion, not `: BlockchainImplementation`
-- **Lazy double-call** - `blockchains.chain(options)()` first passes config, second triggers async import
+- **Class pattern** - every blockchain exports a named concrete class and the same class as its default export
+- **Abstract bases** - all chains extend `AbstractBlockchain`; Ethereum and Base extend `AbstractEVMBlockchain`
+- **Lazy double-call** - `blockchains.chain(options)()` passes constructor options, then imports and constructs the class
 - **Curve-split signing** - secp256k1 chains use `evmSignMessage` (Ethereum preamble + keccak256), ed25519 chains use `ed25519SignMessage` (raw, no prehash)
 - **Test mirrors src** - `src/blockchains/bitcoin.ts` -> `test/blockchains/bitcoin.test.ts`
 - **Shared fixtures** - test vectors live in `test/fixtures.ts`, not duplicated per test file
@@ -60,7 +60,7 @@ ubichain/
 - **No type assertions in src/** - zero `as any`, `@ts-ignore`, `@ts-expect-error` in source code (`@ts-expect-error` exists in tests only, for intentional invalid input testing)
 - **No non-noble crypto** - never use Node `crypto` module for hashing/signing (only `webcrypto.getRandomValues` for key generation)
 - **No logic in index.ts** - only re-exports
-- **No direct blockchain instantiation** - always go through `_blockchains.ts` lazy loader for public API
+- **Don't bypass the lazy registry by accident** - use `blockchains.chain(options)()` for routine public loading; direct constructors are for explicit per-chain imports and subclassing
 - **Don't mix signing utils** - secp256k1 chains must use `evmSignMessage`, ed25519 chains must use `ed25519SignMessage` or chain-specific variant
 
 ## COMMANDS

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pnpm add ubichain
 
 ## Usage
 
-Blockchain implementations are lazy-loaded. The double-call pattern `blockchains.chain(options)()` first passes config, then triggers the async import.
+Concrete blockchain classes are lazy-loaded. The double-call pattern `blockchains.chain(options)()` first passes config, then imports and constructs the class.
 
 ### Generate a wallet
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Concrete blockchain classes are lazy-loaded. The double-call pattern `blockchain
 ```ts
 import { useBlockchain, blockchains } from "ubichain";
 
-const impl = await blockchains.ethereum()();
-const chain = useBlockchain(impl);
+const ethereum = await blockchains.ethereum()();
+const chain = useBlockchain(ethereum);
 
 const wallet = chain.generateWallet();
 console.log(wallet.keys.private); // hex private key

--- a/docs/1.guide/1.index.md
+++ b/docs/1.guide/1.index.md
@@ -31,13 +31,12 @@ Install [`ubichain`](https://npmjs.com/package/ubichain) npm package:
 ```js [my-wallet.js]
 import { useBlockchain, blockchains } from "ubichain";
 
-// Using lazy factories for better performance and tree-shaking
-// Create blockchain interfaces with lazy loading
-const bitcoinImpl = await blockchains.bitcoin()();
-const ethereumImpl = await blockchains.ethereum()();
+// Lazy loading imports and constructs concrete blockchain classes on demand
+const bitcoin = await blockchains.bitcoin()();
+const ethereum = await blockchains.ethereum()();
 
-const bitcoinChain = useBlockchain(bitcoinImpl);
-const ethereumChain = useBlockchain(ethereumImpl);
+const bitcoinChain = useBlockchain(bitcoin);
+const ethereumChain = useBlockchain(ethereum);
 
 // Generate a complete wallet for each blockchain
 const btcWallet = bitcoinChain.generateWallet();
@@ -75,11 +74,11 @@ Ubichain currently supports the following blockchains:
 Ubichain uses lazy loading to improve performance and reduce bundle size. Each blockchain implementation is loaded on-demand only when you need it:
 
 ```js
-// The blockchain implementation is only loaded when you call this function
-const bitcoinImpl = await blockchains.bitcoin()();
+// The concrete class is imported and instantiated only when this function is called
+const bitcoin = await blockchains.bitcoin()();
 
-// You can pass options to configure the blockchain
-const testnetImpl = await blockchains.bitcoin({ network: "testnet" })();
+// Constructor options are passed before triggering the lazy import
+const testnet = await blockchains.bitcoin({ network: "testnet" })();
 ```
 
 ### Cryptographic Curves

--- a/docs/1.guide/2.keys.md
+++ b/docs/1.guide/2.keys.md
@@ -14,9 +14,9 @@ All blockchains in ubichain share a common implementation for generating private
 
 ```js
 import { useBlockchain } from "ubichain";
-import bitcoin from "ubichain/blockchains/bitcoin";
+import Bitcoin from "ubichain/blockchains/bitcoin";
 
-const chain = useBlockchain(bitcoin());
+const chain = useBlockchain(new Bitcoin());
 const privateKey = chain.generateKeyPrivate();
 
 console.log(privateKey); // e.g., '7f9e5b9e3bbed34a4c28c8c1665525fc2cd7afb4fdc7edca3eb93ddf8a31ef56'
@@ -96,9 +96,9 @@ You can specify the curve to use when generating a public key:
 
 ```js
 import { useBlockchain } from "ubichain";
-import sui from "ubichain/blockchains/sui";
+import Sui from "ubichain/blockchains/sui";
 
-const suiChain = useBlockchain(sui());
+const suiChain = useBlockchain(new Sui());
 
 // Generate a public key using Ed25519 (default for SUI)
 const ed25519PublicKey = suiChain.getKeyPublic(privateKey);
@@ -115,7 +115,7 @@ Under the hood, ubichain uses the following libraries for cryptographic operatio
 - **@noble/hashes**: For cryptographic hash functions (SHA-256, RIPEMD-160, Keccak-256)
 - **Node.js crypto**: For secure random number generation
 
-For EVM-compatible blockchains, a common implementation is shared through the `utils/evm.ts` module, which provides consistent key generation and address derivation across all EVM chains.
+For EVM-compatible blockchains, `AbstractEVMBlockchain` provides the shared key generation, address derivation, validation, and signing behavior used by the concrete EVM classes.
 
 You can check which curve a blockchain uses with the `curve` property:
 

--- a/docs/1.guide/3.addresses.md
+++ b/docs/1.guide/3.addresses.md
@@ -12,9 +12,9 @@ Once you have a public key, you can derive a blockchain address from it. Each bl
 
 ```js
 import { useBlockchain } from "ubichain";
-import bitcoin from "ubichain/blockchains/bitcoin";
+import Bitcoin from "ubichain/blockchains/bitcoin";
 
-const chain = useBlockchain(bitcoin());
+const chain = useBlockchain(new Bitcoin());
 const keys = chain.generateKeys();
 const address = chain.getAddress(keys.keys.public);
 
@@ -37,11 +37,11 @@ For blockchains with only one address type, the second parameter is ignored.
 
 ## Address Validation
 
-Ubichain provides address validation functionality through the optional `validateAddress` method:
+Ubichain's concrete blockchain classes implement address validation through the `validateAddress` method:
 
 ```js
 // Validate a Bitcoin address
-const isValid = chain.validateAddress?.("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa");
+const isValid = chain.validateAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa");
 
 if (isValid) {
   console.log("Address is valid");
@@ -51,7 +51,7 @@ if (isValid) {
 ```
 
 ::note
-The `validateAddress` method is optional and may not be implemented for all blockchains. Always use the optional chaining operator (`?.`) when calling this method.
+`BlockchainImplementation` keeps `validateAddress` optional for structural compatibility, but every class derived from `AbstractBlockchain` must implement it.
 ::
 
 ## Address Formats by Blockchain
@@ -64,7 +64,7 @@ Each blockchain has its own address format and derivation algorithm:
 - **P2SH**: Base58Check encoded addresses starting with '3'
 
 ```js
-const bitcoinChain = useBlockchain(bitcoin());
+const bitcoinChain = useBlockchain(new Bitcoin());
 const publicKey = bitcoinChain.getKeyPublic(privateKey);
 
 // Legacy address (P2PKH)
@@ -80,7 +80,7 @@ const p2shAddress = bitcoinChain.getAddress(publicKey, "p2sh"); // '3...'
 - Implements EIP-55 checksum for case-sensitive validation
 
 ```js
-const ethereumChain = useBlockchain(ethereum());
+const ethereumChain = useBlockchain(new Ethereum());
 const publicKey = ethereumChain.getKeyPublic(privateKey);
 const address = ethereumChain.getAddress(publicKey); // '0x...'
 ```
@@ -90,7 +90,7 @@ const address = ethereumChain.getAddress(publicKey); // '0x...'
 - Base58 encoded addresses (the public key itself serves as the address)
 
 ```js
-const solanaChain = useBlockchain(solana());
+const solanaChain = useBlockchain(new Solana());
 const publicKey = solanaChain.getKeyPublic(privateKey);
 const address = solanaChain.getAddress(publicKey);
 ```
@@ -100,7 +100,7 @@ const address = solanaChain.getAddress(publicKey);
 - Hex encoded addresses with '0x' prefix
 
 ```js
-const aptosChain = useBlockchain(aptos());
+const aptosChain = useBlockchain(new Aptos());
 const publicKey = aptosChain.getKeyPublic(privateKey);
 const address = aptosChain.getAddress(publicKey); // '0x...'
 ```
@@ -110,7 +110,7 @@ const address = aptosChain.getAddress(publicKey); // '0x...'
 - Base58Check encoded addresses starting with 'T'
 
 ```js
-const tronChain = useBlockchain(tron());
+const tronChain = useBlockchain(new Tron());
 const publicKey = tronChain.getKeyPublic(privateKey);
 const address = tronChain.getAddress(publicKey); // 'T...'
 ```
@@ -121,7 +121,7 @@ const address = tronChain.getAddress(publicKey); // 'T...'
 - Supports both Ed25519 and Secp256k1 keys
 
 ```js
-const suiChain = useBlockchain(sui());
+const suiChain = useBlockchain(new Sui());
 
 // Default is Ed25519
 const ed25519PublicKey = suiChain.getKeyPublic(privateKey);

--- a/docs/1.guide/4.wallets.md
+++ b/docs/1.guide/4.wallets.md
@@ -30,9 +30,9 @@ Ubichain provides a convenient way to generate a complete wallet in one step:
 
 ```js
 import { useBlockchain } from "ubichain";
-import bitcoin from "ubichain/blockchains/bitcoin";
+import Bitcoin from "ubichain/blockchains/bitcoin";
 
-const chain = useBlockchain(bitcoin());
+const chain = useBlockchain(new Bitcoin());
 const wallet = chain.generateWallet();
 
 console.log("Private Key:", wallet.keys.private);
@@ -51,7 +51,7 @@ You can pass options to the `generateWallet` method to customize the wallet gene
 const uncompressedWallet = chain.generateWallet({ compressed: false });
 
 // Generate a Bitcoin P2SH wallet
-const bitcoinChain = useBlockchain(bitcoin());
+const bitcoinChain = useBlockchain(new Bitcoin());
 const p2shWallet = bitcoinChain.generateWallet({}, "p2sh");
 console.log("P2SH Address:", p2shWallet.address); // Starts with '3'
 ```
@@ -65,7 +65,7 @@ Each blockchain has its own wallet format:
 ### Bitcoin Wallet
 
 ```js
-const bitcoinChain = useBlockchain(bitcoin());
+const bitcoinChain = useBlockchain(new Bitcoin());
 const btcWallet = bitcoinChain.generateWallet();
 
 console.log("Bitcoin Private Key:", btcWallet.keys.private);
@@ -76,7 +76,7 @@ console.log("Bitcoin Address:", btcWallet.address); // Starts with '1'
 ### Ethereum Wallet
 
 ```js
-const ethereumChain = useBlockchain(ethereum());
+const ethereumChain = useBlockchain(new Ethereum());
 const ethWallet = ethereumChain.generateWallet();
 
 console.log("Ethereum Private Key:", ethWallet.keys.private);
@@ -87,7 +87,7 @@ console.log("Ethereum Address:", ethWallet.address); // Starts with '0x'
 ### Solana Wallet
 
 ```js
-const solanaChain = useBlockchain(solana());
+const solanaChain = useBlockchain(new Solana());
 const solWallet = solanaChain.generateWallet();
 
 console.log("Solana Private Key:", solWallet.keys.private);
@@ -146,16 +146,16 @@ Ubichain is primarily a tool for interacting with blockchain protocols. It does 
 
 ## Implementation Details
 
-The wallet generation functionality is implemented in the `blockchain.ts` file, with the following structure:
+The shared wallet-generation method lives on `AbstractBlockchain`:
 
-```js
-function generateWallet(options?, addressType?) {
-  const keyPair = generateKeys(options);
-  const address = blockchain.getAddress(keyPair.keys.public, addressType);
+```ts
+generateWallet(options?: KeyOptions, addressType?: AddressType): Wallet {
+  const keys = this.generateKeys(options);
+  const address = this.getAddress(keys.keys.public, addressType);
 
   return {
-    ...keyPair,
-    address
+    ...keys,
+    address,
   };
 }
 ```

--- a/docs/1.guide/5.evm.md
+++ b/docs/1.guide/5.evm.md
@@ -23,15 +23,16 @@ More EVM chains will be added in future releases.
 
 ## Common EVM Implementation
 
-All EVM chains in ubichain use the same underlying implementation, provided by the `utils/evm.ts` module. This ensures consistent behavior across all EVM chains.
+All EVM chains extend `AbstractEVMBlockchain`, which provides their shared key generation, address derivation, validation, and signing behavior.
 
-Creating a new EVM blockchain implementation is as simple as:
+Creating a new EVM blockchain class only requires its name and BIP44 coin type:
 
-```js
-import { createEVMBlockchain } from "../utils/evm";
+```ts
+import { AbstractEVMBlockchain, BIP44 } from "ubichain";
 
-export default function ethereum() {
-  return createEVMBlockchain("ethereum");
+export default class Ethereum extends AbstractEVMBlockchain {
+  override readonly name = "ethereum";
+  override readonly bip44 = BIP44.ETHEREUM;
 }
 ```
 
@@ -65,12 +66,12 @@ An important property of EVM chains is that the same private key will generate t
 
 ```js
 import { useBlockchain } from "ubichain";
-import ethereum from "ubichain/blockchains/ethereum";
-import base from "ubichain/blockchains/base";
+import Ethereum from "ubichain/blockchains/ethereum";
+import Base from "ubichain/blockchains/base";
 
-// Create blockchain interfaces
-const ethereumChain = useBlockchain(ethereum());
-const baseChain = useBlockchain(base());
+// Construct concrete blockchain classes
+const ethereumChain = useBlockchain(new Ethereum());
+const baseChain = useBlockchain(new Base());
 
 // Generate a private key
 const privateKey = ethereumChain.generateKeyPrivate();
@@ -90,7 +91,7 @@ This makes it easy to use the same wallet across multiple EVM chains.
 You can generate wallets for any EVM chain using the `generateWallet` method:
 
 ```js
-const ethereumChain = useBlockchain(ethereum());
+const ethereumChain = useBlockchain(new Ethereum());
 const ethWallet = ethereumChain.generateWallet();
 
 console.log("Ethereum Address:", ethWallet.address);
@@ -104,10 +105,10 @@ Ubichain provides address validation for EVM chains that checks both the format 
 
 ```js
 // Validate an address
-const isValid = ethereumChain.validateAddress?.("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf");
+const isValid = ethereumChain.validateAddress("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf");
 
 // Different case with invalid checksum
-const isInvalid = ethereumChain.validateAddress?.("0x7e5F4552091A69125d5DfCb7b8C2659029395Bdf");
+const isInvalid = ethereumChain.validateAddress("0x7e5F4552091A69125d5DfCb7b8C2659029395Bdf");
 ```
 
 The validation function accepts:
@@ -139,22 +140,23 @@ This standardized approach ensures compatibility with all EVM-based blockchain t
 
 To add support for a new EVM chain, simply create a new file in the `blockchains` directory:
 
-```js
+```ts
 // blockchains/polygon.ts
-import { createEVMBlockchain } from "../utils/evm";
+import { AbstractEVMBlockchain } from "../utils/evm";
 
-export default function polygon() {
-  return createEVMBlockchain("polygon");
+export default class Polygon extends AbstractEVMBlockchain {
+  override readonly name = "polygon";
+  override readonly bip44 = 60;
 }
 ```
 
 Then add it to the list of blockchains in `_blockchains.ts`:
 
-```js
-export const blockchains = Object.freeze({
+```ts
+export const blockchains = {
   // Existing blockchains
-  polygon: "ubichain/blockchains/polygon",
-});
+  polygon: lazy(() => import("./blockchains/polygon.ts")),
+};
 ```
 
-This modular approach makes it easy to extend ubichain with support for additional EVM chains.
+The concrete subclass stays small while the abstract EVM base keeps shared behavior consistent.

--- a/docs/1.guide/6.custom.md
+++ b/docs/1.guide/6.custom.md
@@ -4,224 +4,193 @@ icon: material-symbols:add-circle-outline
 
 # Creating Custom Blockchains
 
-> Learn how to extend ubichain with your own blockchain implementations.
+> Learn how to extend ubichain with a concrete blockchain class.
 
-## Understanding the Blockchain Interface
+## Class Hierarchy
 
-Ubichain is designed to be easily extendable. To add support for a new blockchain, you need to implement the `Blockchain` interface:
+Every built-in chain is a class derived from one of two public bases:
 
-```typescript
-type Blockchain = {
-  name: string;
-  curve: Curve | Curve[];
-  getKeyPublic: (keyPrivate: string, options?: Record<string, any>) => string;
-  getAddress: (keyPublic: string, type?: string) => string;
-  validateAddress?: (address: string) => boolean;
+- `AbstractBlockchain` provides secure private-key generation, key-pair generation, and wallet generation.
+- `AbstractEVMBlockchain` adds the shared secp256k1 key, EIP-55 address, and EVM message-signing behavior.
+
+Concrete classes must provide their chain metadata and the operations that are not supplied by their base class.
+
+## Required Contract
+
+A direct `AbstractBlockchain` subclass implements:
+
+- `name`: the lowercase blockchain identifier
+- `curve`: `"ed25519"`, `"secp256k1"`, or a readonly array for a multi-curve chain
+- `bip44`: the SLIP-0044 coin type
+- `getKeyPublic`: public-key derivation
+- `getAddress`: address derivation
+- `validateAddress`: address validation
+- `signMessage`: message signing
+- `verifyMessage`: signature verification
+
+The base class supplies `network`, `generateKeyPrivate`, `generateKeys`, and `generateWallet`.
+
+## Example Class
+
+The following contributor-side example uses ubichain's existing secp256k1, encoding, and signing utilities:
+
+```ts
+// src/blockchains/mychain.ts
+import { ripemd160 } from "@noble/hashes/legacy.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hexToBytes } from "@noble/hashes/utils.js";
+import { AbstractBlockchain } from "../blockchain.ts";
+import { encodeBase58Check, validateBase58Check } from "../utils/encoding.ts";
+import { generateKeyPublic } from "../utils/secp256k1.ts";
+import {
+  signMessage as genericSignMessage,
+  verifyMessage as genericVerifyMessage,
+} from "../utils/signing.ts";
+import type { Curve, KeyOptions } from "../types.ts";
+
+const ADDRESS_VERSION = 0x34;
+
+export class MyChain extends AbstractBlockchain {
+  override readonly name = "mychain";
+  override readonly curve: Curve = "secp256k1";
+  override readonly bip44 = 1234;
+
+  override getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
+    return generateKeyPublic(keyPrivate, options);
+  }
+
+  override getAddress(keyPublic: string): string {
+    const publicKey = hexToBytes(keyPublic);
+    const hash = ripemd160(sha256(publicKey));
+    const payload = new Uint8Array(hash.length + 1);
+    payload[0] = ADDRESS_VERSION;
+    payload.set(hash, 1);
+    return encodeBase58Check(payload);
+  }
+
+  override validateAddress(address: string): boolean {
+    return validateBase58Check(address, ADDRESS_VERSION);
+  }
+
+  override signMessage(
+    message: string | Uint8Array,
+    keyPrivate: string,
+    options?: KeyOptions,
+  ): string {
+    return genericSignMessage(message, keyPrivate, {
+      curve: "secp256k1",
+      ...options,
+    });
+  }
+
+  override verifyMessage(
+    message: string | Uint8Array,
+    signature: string,
+    keyPublic: string,
+    options?: KeyOptions,
+  ): boolean {
+    return genericVerifyMessage(message, signature, keyPublic, {
+      curve: "secp256k1",
+      ...options,
+    });
+  }
+}
+
+export default MyChain;
+```
+
+The `bip44` value above is illustrative. A real chain implementation must use its assigned SLIP-0044 coin type.
+
+## Constructing the Class
+
+Direct per-chain imports expose the constructor:
+
+```ts
+import { useBlockchain } from "ubichain";
+import MyChain from "ubichain/blockchains/mychain";
+
+const chain = useBlockchain(new MyChain({ network: "testnet" }));
+const wallet = chain.generateWallet();
+```
+
+`useBlockchain` preserves the concrete class type and returns the same instance.
+
+## Registering Lazy Loading
+
+Built-in chains are also registered in `src/_blockchains.ts`. Add the class module to the `blockchains` object:
+
+```ts
+export const blockchains = {
+  // Existing chains
+  mychain: lazy(() => import("./blockchains/mychain.ts")),
 };
 ```
 
-The interface has the following components:
+Consumers can then load and construct the class on demand:
 
-- `name`: A string identifier for the blockchain
-- `curve`: The cryptographic curve(s) used by the blockchain (`'ed25519'` or `'secp256k1'` or an array)
-- `getKeyPublic`: A function that derives a public key from a private key
-- `getAddress`: A function that derives an address from a public key
-- `validateAddress`: An optional function that validates an address (returns a boolean)
+```ts
+import { blockchains, useBlockchain } from "ubichain";
 
-## Implementation Structure
-
-A typical blockchain implementation follows this structure:
-
-```js
-import { generateKeyPublic as getSecp256k1KeyPublic } from '../utils/secp256k1';
-import type { Curve } from '../types';
-
-export default function myBlockchain() {
-  const name = "myblockchain";
-  const curve: Curve = "secp256k1";
-
-  function getKeyPublic(keyPrivate: string, options?: Record<string, any>): string {
-    // Implement key derivation logic
-    return getSecp256k1KeyPublic(keyPrivate, options);
-  }
-
-  function getAddress(keyPublic: string, type?: string): string {
-    // Implement address derivation logic
-    return /* derived address */;
-  }
-
-  function validateAddress(address: string): boolean {
-    // Implement address validation logic
-    return /* validation result */;
-  }
-
-  return {
-    name,
-    curve,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-  };
-}
+const chain = useBlockchain(await blockchains.mychain({ network: "testnet" })());
 ```
 
-## Example: Creating a Simple Blockchain Implementation
+The first call passes constructor options. The second call triggers the dynamic import and returns the concrete instance.
 
-Let's create a simple blockchain implementation for a fictional blockchain called "MyChain" that uses the secp256k1 curve:
+## EVM-Compatible Chains
 
-```js
-// blockchains/mychain.ts
-import { generateKeyPublic as getSecp256k1KeyPublic } from '../utils/secp256k1';
-import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
-import { sha256 } from '@noble/hashes/sha2.js';
-import { ripemd160 } from '@noble/hashes/legacy.js';
-import { encodeBase58Check } from '../utils/encoding';
-import type { Curve } from '../types';
+An EVM-compatible chain should extend `AbstractEVMBlockchain` instead of repeating shared behavior:
 
-export default function mychain() {
-  const name = "mychain";
-  const curve: Curve = "secp256k1";
+```ts
+// src/blockchains/arbitrum.ts
+import { AbstractEVMBlockchain } from "../utils/evm.ts";
+import { BIP44 } from "../utils/bip44/index.ts";
 
-  function getKeyPublic(keyPrivate: string, options?: Record<string, any>): string {
-    return getSecp256k1KeyPublic(keyPrivate, options);
-  }
-
-  function getAddress(keyPublic: string): string {
-    // Convert public key to bytes
-    const keyPublicBytes = hexToBytes(keyPublic);
-
-    // Hash the public key (SHA-256 followed by RIPEMD-160)
-    const hash = ripemd160(sha256(keyPublicBytes));
-
-    // Add version byte (0x4D for "M" prefix)
-    const hashVersioned = new Uint8Array(hash.length + 1);
-    hashVersioned[0] = 0x4D;
-    hashVersioned.set(hash, 1);
-
-    // Encode with Base58Check
-    return encodeBase58Check(hashVersioned);
-  }
-
-  function validateAddress(address: string): boolean {
-    // Basic validation: check it starts with "M" and has correct length
-    if (!address.startsWith('M')) {
-      return false;
-    }
-
-    try {
-      // Try to decode the address (will throw if invalid)
-      // Full implementation would do more thorough validation
-      return address.length >= 26 && address.length <= 35;
-    } catch (error) {
-      return false;
-    }
-  }
-
-  return {
-    name,
-    curve,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-  };
-}
-```
-
-## Registering Your Blockchain
-
-After creating your blockchain implementation, add it to the `_blockchains.ts` file:
-
-```js
-export const blockchains = Object.freeze({
-  bitcoin: "ubichain/blockchains/bitcoin",
-  ethereum: "ubichain/blockchains/ethereum",
-  // ... other blockchains
-  mychain: "ubichain/blockchains/mychain",
-});
-```
-
-## Using Shared Implementations
-
-For blockchains with similar characteristics, you can use shared implementations:
-
-### EVM Chains
-
-For EVM-compatible blockchains, you can use the `createEVMBlockchain` factory function:
-
-```js
-// blockchains/arbitrum.ts
-import { createEVMBlockchain } from "../utils/evm";
-
-export default function arbitrum() {
-  return createEVMBlockchain("arbitrum");
-}
-```
-
-### Custom Shared Implementations
-
-You can create your own shared implementations for families of blockchains:
-
-```js
-// utils/cosmos.ts
-export function createCosmosBlockchain(name: string) {
-  // Implement common Cosmos SDK blockchain logic
-  return {
-    name,
-    curve: 'secp256k1',
-    getKeyPublic, // Common implementation
-    getAddress,   // Common implementation
-    validateAddress, // Common implementation
-  };
+export class Arbitrum extends AbstractEVMBlockchain {
+  override readonly name = "arbitrum";
+  override readonly bip44 = BIP44.ETHEREUM;
 }
 
-// blockchains/cosmos.ts
-import { createCosmosBlockchain } from '../utils/cosmos';
-
-export default function cosmos() {
-  return createCosmosBlockchain("cosmos");
-}
+export default Arbitrum;
 ```
 
-## Testing Your Implementation
+The EVM base class already implements key derivation, address generation and validation, and message signing and verification.
 
-Create a test file for your blockchain implementation:
+## Testing the Class
 
-```js
+Mirror the source path under `test/` and construct the class with `new`:
+
+```ts
 // test/blockchains/mychain.test.ts
 import { describe, expect, it } from "vitest";
 import { useBlockchain } from "../../src";
-import mychain from "../../src/blockchains/mychain";
+import MyChain from "../../src/blockchains/mychain";
 
-describe("MyChain blockchain", () => {
-  const blockchain = useBlockchain(mychain());
+describe("MyChain", () => {
+  const blockchain = useBlockchain(new MyChain());
 
-  it("should have a name", () => {
+  it("exposes its chain metadata", () => {
     expect(blockchain.name).toBe("mychain");
-  });
-
-  it("should use secp256k1 curve", () => {
     expect(blockchain.curve).toBe("secp256k1");
+    expect(blockchain.network).toBe("mainnet");
   });
 
-  // Test key and address generation
-  // ...
+  it("generates self-validating wallets", () => {
+    const wallet = blockchain.generateWallet();
+    expect(blockchain.validateAddress(wallet.address)).toBe(true);
+  });
 });
 ```
 
-Run the tests with:
+Run the focused test:
 
 ```bash
-pnpm dev
+pnpm exec vitest run test/blockchains/mychain.test.ts
 ```
 
 ## Best Practices
 
-When implementing a new blockchain:
-
-1. **Research the blockchain's specifications** - Understand its key formats, address derivation, and validation rules
-2. **Use existing utilities** - Leverage the utility functions in ubichain for common operations
-3. **Add comprehensive tests** - Ensure your implementation works correctly with known test vectors
-4. **Document your implementation** - Add comments explaining the algorithms and format specifications
-5. **Follow the project's coding style** - Maintain consistency with the rest of the codebase
-
-By following these guidelines, you can contribute new blockchain implementations to ubichain or create custom implementations for your own projects.
+1. Verify the chain's key, address, and signing rules against published test vectors.
+2. Reuse the existing @noble/@scure-based utilities instead of adding another crypto implementation.
+3. Keep network parameters in one record rather than repeating network conditionals.
+4. Export the concrete class by name and as the default export.
+5. Register the class in the lazy loader and mirror its source path in tests.

--- a/docs/1.guide/6.custom.md
+++ b/docs/1.guide/6.custom.md
@@ -117,13 +117,10 @@ const wallet = chain.generateWallet();
 
 ## Registering Lazy Loading
 
-Built-in chains are also registered in `src/_blockchains.ts`. Add the class module to the `blockchains` object:
+Built-in chains are registered in `src/_blockchains.ts`. Add this property inside the existing `blockchains` object, where the module-private `lazy` helper is available:
 
 ```ts
-export const blockchains = {
-  // Existing chains
-  mychain: lazy(() => import("./blockchains/mychain.ts")),
-};
+mychain: lazy(() => import("./blockchains/mychain.ts")),
 ```
 
 Consumers can then load and construct the class on demand:

--- a/docs/2.blockchains/aptos.md
+++ b/docs/2.blockchains/aptos.md
@@ -14,9 +14,9 @@ Aptos implementation using the ed25519 curve, with addresses derived using SHA3-
 
 ```js
 import { useBlockchain } from "ubichain";
-import aptos from "ubichain/blockchains/aptos";
+import Aptos from "ubichain/blockchains/aptos";
 
-const aptosChain = useBlockchain(aptos());
+const aptosChain = useBlockchain(new Aptos());
 ```
 
 ## Features
@@ -50,13 +50,13 @@ console.log("Address:", address); // e.g., 0x7e08ac7940568c91564ddc6f5f3bf91b15a
 
 ```js
 // Validate an Aptos address
-const isValid = aptosChain.validateAddress?.(
+const isValid = aptosChain.validateAddress(
   "0x7e08ac7940568c91564ddc6f5f3bf91b15a9334194ab7855daeac51c5cc74936",
 );
 console.log("Is valid:", isValid); // true
 
 // Invalid address (wrong format)
-const isInvalid = aptosChain.validateAddress?.(
+const isInvalid = aptosChain.validateAddress(
   "7e08ac7940568c91564ddc6f5f3bf91b15a9334194ab7855daeac51c5cc74936",
 );
 console.log("Is valid:", isInvalid); // false (missing 0x prefix)

--- a/docs/2.blockchains/base.md
+++ b/docs/2.blockchains/base.md
@@ -14,9 +14,9 @@ Base implementation using the secp256k1 curve, with EIP-55 checksum support for 
 
 ```js
 import { useBlockchain } from "ubichain";
-import base from "ubichain/blockchains/base";
+import Base from "ubichain/blockchains/base";
 
-const baseChain = useBlockchain(base());
+const baseChain = useBlockchain(new Base());
 ```
 
 ## Features
@@ -53,15 +53,15 @@ console.log("Address:", address); // 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
 
 ```js
 // Validate a checksummed address
-const isValidChecksum = baseChain.validateAddress?.("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf");
+const isValidChecksum = baseChain.validateAddress("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf");
 console.log("Is valid:", isValidChecksum); // true
 
 // Validate a lowercase address (also valid)
-const isValidLowercase = baseChain.validateAddress?.("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
+const isValidLowercase = baseChain.validateAddress("0x7e5f4552091a69125d5dfcb7b8c2659029395bdf");
 console.log("Is valid:", isValidLowercase); // true
 
 // Invalid checksum (wrong case)
-const isInvalidChecksum = baseChain.validateAddress?.("0x7e5F4552091A69125d5DfCb7b8C2659029395Bdf");
+const isInvalidChecksum = baseChain.validateAddress("0x7e5F4552091A69125d5DfCb7b8C2659029395Bdf");
 console.log("Is valid:", isInvalidChecksum); // false
 ```
 
@@ -75,13 +75,15 @@ Base is an EVM (Ethereum Virtual Machine) compatible blockchain, which means:
 2. The same private key will generate the same address on both Ethereum and Base
 3. All Base addresses can be used on Ethereum, and vice versa
 
-Base is implemented using the common EVM module in ubichain:
+Base extends ubichain's common EVM base class:
 
 ```js
-import { createEVMBlockchain } from "../utils/evm";
+import { AbstractEVMBlockchain } from "../utils/evm";
+import { BIP44 } from "../utils/bip44";
 
-export default function base() {
-  return createEVMBlockchain("base");
+export default class Base extends AbstractEVMBlockchain {
+  readonly name = "base";
+  readonly bip44 = BIP44.ETHEREUM;
 }
 ```
 
@@ -122,14 +124,16 @@ Base addresses are generated following the Ethereum standard:
 
 ## Source Code
 
-The Base implementation is located in `src/blockchains/base.ts` and uses the common EVM implementation from `src/utils/evm.ts`.
+The Base implementation is located in `src/blockchains/base.ts` and extends `AbstractEVMBlockchain` from `src/utils/evm.ts`.
 
 ```js
 // Base implementation
-import { createEVMBlockchain } from "../utils/evm";
+import { AbstractEVMBlockchain } from "../utils/evm";
+import { BIP44 } from "../utils/bip44";
 
-export default function base() {
-  return createEVMBlockchain("base");
+export default class Base extends AbstractEVMBlockchain {
+  readonly name = "base";
+  readonly bip44 = BIP44.ETHEREUM;
 }
 ```
 

--- a/docs/2.blockchains/base.md
+++ b/docs/2.blockchains/base.md
@@ -82,8 +82,8 @@ import { AbstractEVMBlockchain } from "../utils/evm";
 import { BIP44 } from "../utils/bip44";
 
 export default class Base extends AbstractEVMBlockchain {
-  readonly name = "base";
-  readonly bip44 = BIP44.ETHEREUM;
+  override readonly name = "base";
+  override readonly bip44 = BIP44.ETHEREUM;
 }
 ```
 
@@ -132,8 +132,8 @@ import { AbstractEVMBlockchain } from "../utils/evm";
 import { BIP44 } from "../utils/bip44";
 
 export default class Base extends AbstractEVMBlockchain {
-  readonly name = "base";
-  readonly bip44 = BIP44.ETHEREUM;
+  override readonly name = "base";
+  override readonly bip44 = BIP44.ETHEREUM;
 }
 ```
 

--- a/docs/2.blockchains/bitcoin.md
+++ b/docs/2.blockchains/bitcoin.md
@@ -14,9 +14,9 @@ Bitcoin implementation using the secp256k1 curve, supporting legacy (P2PKH), P2S
 
 ```js
 import { useBlockchain } from "ubichain";
-import bitcoin from "ubichain/blockchains/bitcoin";
+import Bitcoin from "ubichain/blockchains/bitcoin";
 
-const bitcoinChain = useBlockchain(bitcoin());
+const bitcoinChain = useBlockchain(new Bitcoin());
 ```
 
 ## Features
@@ -82,16 +82,16 @@ const taprootAddress = bitcoinChain.getAddress(publicKey, "taproot");
 
 ```js
 // Validate a legacy address
-const isValidLegacy = bitcoinChain.validateAddress?.("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2");
+const isValidLegacy = bitcoinChain.validateAddress("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2");
 
 // Validate a P2SH address
-const isValidP2SH = bitcoinChain.validateAddress?.("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy");
+const isValidP2SH = bitcoinChain.validateAddress("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy");
 
 // Validate a SegWit v0 address
-const isValidSegWit = bitcoinChain.validateAddress?.("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+const isValidSegWit = bitcoinChain.validateAddress("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
 
 // Validate a Taproot (SegWit v1) address
-const isValidTaproot = bitcoinChain.validateAddress?.(
+const isValidTaproot = bitcoinChain.validateAddress(
   "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
 );
 ```

--- a/docs/2.blockchains/cardano.md
+++ b/docs/2.blockchains/cardano.md
@@ -6,9 +6,9 @@ This document explains how to use the Cardano blockchain functionality in ubicha
 
 ```javascript
 import { useBlockchain } from "ubichain";
-import cardano from "ubichain/blockchains/cardano";
+import Cardano from "ubichain/blockchains/cardano";
 
-const cardanoBlockchain = useBlockchain(cardano());
+const cardanoBlockchain = useBlockchain(new Cardano());
 ```
 
 ## Features

--- a/docs/2.blockchains/ethereum.md
+++ b/docs/2.blockchains/ethereum.md
@@ -14,9 +14,9 @@ Ethereum implementation using the secp256k1 curve, with EIP-55 checksum support 
 
 ```js
 import { useBlockchain } from "ubichain";
-import ethereum from "ubichain/blockchains/ethereum";
+import Ethereum from "ubichain/blockchains/ethereum";
 
-const ethereumChain = useBlockchain(ethereum());
+const ethereumChain = useBlockchain(new Ethereum());
 ```
 
 ## Features
@@ -53,17 +53,15 @@ console.log("Address:", address); // 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
 
 ```js
 // Validate a checksummed address
-const isValidChecksum = ethereumChain.validateAddress?.(
-  "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
-);
+const isValidChecksum = ethereumChain.validateAddress("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf");
 
 // Validate a lowercase address (also valid)
-const isValidLowercase = ethereumChain.validateAddress?.(
+const isValidLowercase = ethereumChain.validateAddress(
   "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
 );
 
 // Invalid checksum (wrong case)
-const isInvalidChecksum = ethereumChain.validateAddress?.(
+const isInvalidChecksum = ethereumChain.validateAddress(
   "0x7e5F4552091A69125d5DfCb7b8C2659029395Bdf",
 );
 ```
@@ -107,20 +105,22 @@ Ethereum addresses are generated as follows:
 
 ## EVM Compatibility
 
-Ethereum is an EVM (Ethereum Virtual Machine) blockchain. All EVM-compatible blockchains in ubichain share the same implementation through the `utils/evm.ts` module.
+Ethereum is an EVM (Ethereum Virtual Machine) blockchain. All EVM-compatible blockchains in ubichain inherit the same behavior from `AbstractEVMBlockchain`.
 
 This means that the same private key will generate the same address on all EVM chains, including Ethereum, Base, and any other EVM-compatible blockchains that may be added in the future.
 
 ## Source Code
 
-The Ethereum implementation is located in `src/blockchains/ethereum.ts` and uses the common EVM implementation from `src/utils/evm.ts`.
+The Ethereum implementation is located in `src/blockchains/ethereum.ts` and extends the common EVM base class from `src/utils/evm.ts`.
 
 ```js
 // Ethereum implementation
-import { createEVMBlockchain } from "../utils/evm";
+import { AbstractEVMBlockchain } from "../utils/evm";
+import { BIP44 } from "../utils/bip44";
 
-export default function ethereum() {
-  return createEVMBlockchain("ethereum");
+export default class Ethereum extends AbstractEVMBlockchain {
+  readonly name = "ethereum";
+  readonly bip44 = BIP44.ETHEREUM;
 }
 ```
 

--- a/docs/2.blockchains/solana.md
+++ b/docs/2.blockchains/solana.md
@@ -14,9 +14,9 @@ Solana implementation using the ed25519 curve, with simple base58-encoded addres
 
 ```js
 import { useBlockchain } from "ubichain";
-import solana from "ubichain/blockchains/solana";
+import Solana from "ubichain/blockchains/solana";
 
-const solanaChain = useBlockchain(solana());
+const solanaChain = useBlockchain(new Solana());
 ```
 
 ## Features
@@ -50,7 +50,7 @@ console.log("Address:", address);
 
 ```js
 // Validate a Solana address
-const isValid = solanaChain.validateAddress?.("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin");
+const isValid = solanaChain.validateAddress("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin");
 console.log("Is valid:", isValid); // true or false
 ```
 

--- a/docs/2.blockchains/sui.md
+++ b/docs/2.blockchains/sui.md
@@ -14,9 +14,9 @@ SUI implementation supporting both ed25519 and secp256k1 curves, with addresses 
 
 ```js
 import { useBlockchain } from "ubichain";
-import sui from "ubichain/blockchains/sui";
+import Sui from "ubichain/blockchains/sui";
 
-const suiChain = useBlockchain(sui());
+const suiChain = useBlockchain(new Sui());
 ```
 
 ## Features
@@ -68,13 +68,13 @@ console.log("Address (secp256k1):", addressSecp);
 
 ```js
 // Validate a SUI address
-const isValid = suiChain.validateAddress?.(
+const isValid = suiChain.validateAddress(
   "0x7e08ac7940568c91564ddc6f5f3bf91b15a9334194ab7855daeac51c5cc74936",
 );
 console.log("Is valid:", isValid); // true
 
 // Invalid address (wrong format)
-const isInvalid = suiChain.validateAddress?.(
+const isInvalid = suiChain.validateAddress(
   "7e08ac7940568c91564ddc6f5f3bf91b15a9334194ab7855daeac51c5cc74936",
 );
 console.log("Is valid:", isInvalid); // false (missing 0x prefix)

--- a/docs/2.blockchains/tron.md
+++ b/docs/2.blockchains/tron.md
@@ -14,9 +14,9 @@ TRON implementation using the secp256k1 curve, with Base58Check-encoded addresse
 
 ```js
 import { useBlockchain } from "ubichain";
-import tron from "ubichain/blockchains/tron";
+import Tron from "ubichain/blockchains/tron";
 
-const tronChain = useBlockchain(tron());
+const tronChain = useBlockchain(new Tron());
 ```
 
 ## Features
@@ -52,11 +52,11 @@ console.log("Address:", address); // e.g., TJCnKsPa7y5okkXvQAidZBzqx3QyQ6sxMW
 
 ```js
 // Validate a TRON address
-const isValid = tronChain.validateAddress?.("TJCnKsPa7y5okkXvQAidZBzqx3QyQ6sxMW");
+const isValid = tronChain.validateAddress("TJCnKsPa7y5okkXvQAidZBzqx3QyQ6sxMW");
 console.log("Is valid:", isValid); // true
 
 // Invalid address (wrong prefix)
-const isInvalid = tronChain.validateAddress?.("1JCnKsPa7y5okkXvQAidZBzqx3QyQ6sxMW");
+const isInvalid = tronChain.validateAddress("1JCnKsPa7y5okkXvQAidZBzqx3QyQ6sxMW");
 console.log("Is valid:", isInvalid); // false (doesn't start with T)
 ```
 

--- a/packages/pi/AGENTS.md
+++ b/packages/pi/AGENTS.md
@@ -13,8 +13,8 @@ Pi coding-agent extension only. Wraps the `ubichain` library as 6 agent tools. *
 - **Library resolution:** `loadLib()` imports built `ubichain` from `dist/`; falls back to `../../../src/index.ts` in dev before a build. Run `pnpm build` before relying on the dist path.
 - **Type-check:** `pnpm test:ext` (`tsc -p ../../tsconfig.extensions.json --noEmit`). Wired into `pnpm test` after `pnpm build` (the extensions tsconfig maps `ubichain` → `dist/index.d.mts`, so dist must exist first).
 - **Tool params:** declared with `typebox` `Type.*`, not zod. Match the existing style.
-- **Required vs optional library methods:** `signMessage`/`verifyMessage` are required on the `Blockchain` interface → call unguarded. `validateAddress` is optional → must guard with `if (!blockchain.validateAddress)`.
-- **Lazy double-call:** `factory({ network })()` — first call passes config, second triggers the async import. See `../../src/_blockchains.ts`.
+- **Concrete class contract:** every lazy-loaded class extends `AbstractBlockchain`, so `validateAddress`, `signMessage`, and `verifyMessage` are required and called directly.
+- **Lazy double-call:** `blockchains.chain({ network })()` — first call passes constructor options, second imports and constructs the concrete class. See `../../src/_blockchains.ts`.
 
 ## Constraints
 

--- a/packages/pi/extensions/ubichain.ts
+++ b/packages/pi/extensions/ubichain.ts
@@ -33,9 +33,9 @@ async function getBlockchain(chain: string, network?: string) {
   if (!Object.hasOwn(lib.blockchains, key)) {
     throw new Error(`Unknown chain "${chain}". Supported: ${CHAINS.join(", ")}`);
   }
-  const factory = lib.blockchains[key];
-  const impl = await factory({ network: network ?? "mainnet" })();
-  return lib.useBlockchain(impl);
+  const loadBlockchain = lib.blockchains[key];
+  const blockchain = await loadBlockchain({ network: network ?? "mainnet" })();
+  return lib.useBlockchain(blockchain);
 }
 
 export default function ubichainExtension(pi: ExtensionAPI) {
@@ -147,17 +147,6 @@ export default function ubichainExtension(pi: ExtensionAPI) {
     },
     async execute(_toolCallId, params): Promise<AgentToolResult<undefined>> {
       const blockchain = await getBlockchain(params.chain, params.network);
-      if (!blockchain.validateAddress) {
-        return {
-          details: undefined,
-          content: [
-            {
-              type: "text",
-              text: `Chain "${params.chain}" does not support address validation`,
-            },
-          ],
-        };
-      }
       const valid = blockchain.validateAddress(params.address);
       return {
         details: undefined,
@@ -338,10 +327,10 @@ export default function ubichainExtension(pi: ExtensionAPI) {
         };
       }
 
-      const factory = lib.blockchains[key];
-      const impl = await factory()();
+      const loadBlockchain = lib.blockchains[key];
+      const blockchain = await loadBlockchain()();
       const path = lib.getBlockchainPath(
-        impl,
+        blockchain,
         params.account ?? 0,
         params.change ?? 0,
         params.addressIndex ?? 0,
@@ -352,9 +341,10 @@ export default function ubichainExtension(pi: ExtensionAPI) {
         content: [
           {
             type: "text",
-            text: [`Chain: ${impl.name} (BIP44 coin type: ${impl.bip44})`, `Path: ${path}`].join(
-              "\n",
-            ),
+            text: [
+              `Chain: ${blockchain.name} (BIP44 coin type: ${blockchain.bip44})`,
+              `Path: ${path}`,
+            ].join("\n"),
           },
         ],
       };

--- a/playground/README.md
+++ b/playground/README.md
@@ -4,16 +4,19 @@ This folder contains example code and experiments demonstrating the usage of ubi
 
 ## Contents
 
-- `bip32-demo.ts` - Demonstrates BIP32 hierarchical deterministic wallet functionality
-- Additional examples will be added as new features are implemented
+- `lazy-class-demo.ts` - Lazy-loads and constructs concrete blockchain classes
+- `signing-demo.ts` - Signs and verifies messages with EVM and Ed25519 classes
+- `bip44-demo.ts` - Uses concrete classes to compare BIP44 paths across all supported chains
+- `bip32-demo.ts` - Demonstrates BIP32 hierarchical deterministic key derivation
+- `bip39-demo.ts` - Generates mnemonics and derives multi-chain seed material
+- `slip10-demo.ts` - Demonstrates hardened Ed25519 derivation with SLIP-0010
 
 ## Running Examples
 
-To run the examples, use the following command:
+Run any example through the project script:
 
 ```bash
-# For BIP32 demo
-npx tsx playground/bip32-demo.ts
+pnpm playground playground/lazy-class-demo.ts
 ```
 
 ## Notes

--- a/playground/bip44-demo.ts
+++ b/playground/bip44-demo.ts
@@ -1,12 +1,12 @@
 import { useBlockchain, BIP44Change, getBlockchainPath } from "../src";
-import bitcoin from "../src/blockchains/bitcoin";
-import ethereum from "../src/blockchains/ethereum";
-import solana from "../src/blockchains/solana";
-import cardano from "../src/blockchains/cardano";
-import tron from "../src/blockchains/tron";
-import aptos from "../src/blockchains/aptos";
-import sui from "../src/blockchains/sui";
-import base from "../src/blockchains/base";
+import Bitcoin from "../src/blockchains/bitcoin";
+import Ethereum from "../src/blockchains/ethereum";
+import Solana from "../src/blockchains/solana";
+import Cardano from "../src/blockchains/cardano";
+import Tron from "../src/blockchains/tron";
+import Aptos from "../src/blockchains/aptos";
+import Sui from "../src/blockchains/sui";
+import Base from "../src/blockchains/base";
 
 import { mnemonicToSeed } from "../src/utils/bip39";
 import {
@@ -20,14 +20,14 @@ import {
 
 // Create blockchain instances
 const chains = [
-  useBlockchain(bitcoin()),
-  useBlockchain(ethereum()),
-  useBlockchain(solana()),
-  useBlockchain(cardano()),
-  useBlockchain(tron()),
-  useBlockchain(aptos()),
-  useBlockchain(sui()),
-  useBlockchain(base()),
+  useBlockchain(new Bitcoin()),
+  useBlockchain(new Ethereum()),
+  useBlockchain(new Solana()),
+  useBlockchain(new Cardano()),
+  useBlockchain(new Tron()),
+  useBlockchain(new Aptos()),
+  useBlockchain(new Sui()),
+  useBlockchain(new Base()),
 ];
 
 // Display BIP44 codes for each blockchain

--- a/playground/lazy-class-demo.ts
+++ b/playground/lazy-class-demo.ts
@@ -1,35 +1,35 @@
 import { useBlockchain, blockchains } from "../src";
 
-console.log("Lazy class demo: only imports the implementation when needed");
+console.log("Lazy class demo: imports and constructs each concrete class only when needed");
 
 // Bitcoin
 console.log("\n--- Bitcoin ---");
-const bitcoinImpl = await blockchains.bitcoin()();
-const btcBlockchain = useBlockchain(bitcoinImpl);
+const bitcoin = await blockchains.bitcoin()();
+const btcBlockchain = useBlockchain(bitcoin);
 
 const btcWallet = btcBlockchain.generateWallet();
 console.log("Bitcoin address:", btcWallet.address);
 
 // Ethereum
 console.log("\n--- Ethereum ---");
-const ethereumImpl = await blockchains.ethereum()();
-const ethBlockchain = useBlockchain(ethereumImpl);
+const ethereum = await blockchains.ethereum()();
+const ethBlockchain = useBlockchain(ethereum);
 
 const ethWallet = ethBlockchain.generateWallet();
 console.log("Ethereum address:", ethWallet.address);
 
 // With options
 console.log("\n--- Bitcoin Testnet ---");
-const testnetImpl = await blockchains.bitcoin({ network: "testnet" })();
-const testnetBlockchain = useBlockchain(testnetImpl);
+const testnet = await blockchains.bitcoin({ network: "testnet" })();
+const testnetBlockchain = useBlockchain(testnet);
 
 const testnetWallet = testnetBlockchain.generateWallet();
 console.log("Bitcoin testnet address:", testnetWallet.address);
 
 // Solana
 console.log("\n--- Solana ---");
-const solanaImpl = await blockchains.solana()();
-const solanaBlockchain = useBlockchain(solanaImpl);
+const solana = await blockchains.solana()();
+const solanaBlockchain = useBlockchain(solana);
 
 const solanaWallet = solanaBlockchain.generateWallet();
 console.log("Solana address:", solanaWallet.address);

--- a/playground/lazy-class-demo.ts
+++ b/playground/lazy-class-demo.ts
@@ -1,6 +1,6 @@
 import { useBlockchain, blockchains } from "../src";
 
-console.log("Lazy factory demo: only imports the implementation when needed");
+console.log("Lazy class demo: only imports the implementation when needed");
 
 // Bitcoin
 console.log("\n--- Bitcoin ---");

--- a/playground/signing-demo.ts
+++ b/playground/signing-demo.ts
@@ -6,8 +6,8 @@ import { useBlockchain } from "../src/blockchain";
 const ethereumImport = await import("../src/blockchains/ethereum");
 const solanaImport = await import("../src/blockchains/solana");
 
-const ethereum = ethereumImport.default;
-const solana = solanaImport.default;
+const Ethereum = ethereumImport.default;
+const Solana = solanaImport.default;
 
 // Generate random private keys
 function generateRandomKeyPrivate(): string {
@@ -17,7 +17,7 @@ function generateRandomKeyPrivate(): string {
 
 // Demo dla podpisów Ethereum (EVM)
 console.log("--- Ethereum Signing Demo ---");
-const ethBlockchain = useBlockchain(ethereum());
+const ethBlockchain = useBlockchain(new Ethereum());
 const ethWallet = ethBlockchain.generateWallet({
   compressed: false, // Ethereum uses uncompressed public keys
 });
@@ -44,7 +44,7 @@ console.log(`Verification with wrong key: ${ethInvalid ? "Valid (error!)" : "Inv
 
 // Demo dla podpisów Solana (Ed25519)
 console.log("\n\n--- Solana Signing Demo ---");
-const solBlockchain = useBlockchain(solana());
+const solBlockchain = useBlockchain(new Solana());
 const solWallet = solBlockchain.generateWallet();
 
 console.log(`Generated Solana wallet:`);

--- a/src/_blockchains.ts
+++ b/src/_blockchains.ts
@@ -1,21 +1,22 @@
-import type { Options, BlockchainImplementation } from "./types.ts";
+import type { AbstractBlockchain } from "./blockchain.ts";
+import type { Options } from "./types.ts";
 
-type BlockchainFactory = (options?: Options) => BlockchainImplementation;
-type BlockchainModule = { default: BlockchainFactory };
+type BlockchainConstructor<T extends AbstractBlockchain> = new (options?: Options) => T;
+type BlockchainModule<T extends AbstractBlockchain> = { default: BlockchainConstructor<T> };
 
 /**
- * Creates a lazy-loaded blockchain factory.
+ * Creates a lazy-loaded blockchain class constructor.
  * The import is deferred until the returned async function is called.
  */
-function lazy(loader: () => Promise<BlockchainModule>) {
-  return (options?: Options) => async (): Promise<BlockchainImplementation> => {
-    const { default: create } = await loader();
-    return create(options);
+function lazy<T extends AbstractBlockchain>(loader: () => Promise<BlockchainModule<T>>) {
+  return (options?: Options) => async (): Promise<T> => {
+    const { default: Blockchain } = await loader();
+    return new Blockchain(options);
   };
 }
 
 /**
- * Blockchain implementations with lazy loading for improved performance and reduced bundle size
+ * Blockchain classes with lazy loading for improved performance and reduced bundle size.
  */
 export const blockchains = {
   bitcoin: lazy(() => import("./blockchains/bitcoin.ts")),

--- a/src/blockchain.ts
+++ b/src/blockchain.ts
@@ -1,46 +1,44 @@
-import type {
-  Blockchain,
-  BlockchainImplementation,
-  Keys,
-  Wallet,
-  KeyOptions,
-  AddressType,
-} from "./types.ts";
 import { webcrypto } from "node:crypto";
 import { bytesToHex } from "@noble/hashes/utils.js";
+import type { AddressType, Blockchain, Curve, KeyOptions, Keys, Options, Wallet } from "./types.ts";
 
 /**
- * Creates and returns an interface using the specified blockchain implementation.
- * This interface allows you to generate keys, addresses,
- * and sign transactions.
- *
- * @param blockchain - The blockchain implementation with the basic required functions.
- * @returns The complete blockchain interface that allows cryptocurrency operations.
+ * Shared blockchain behavior. Concrete chains provide key, address, and signing rules.
  */
-export function useBlockchain(blockchain: BlockchainImplementation): Blockchain {
-  /**
-   * Generates a cryptographically secure random private key
-   * Common implementation for all blockchains - 32 bytes (256 bits)
-   * represented as a 64-character hex string
-   */
-  function generateKeyPrivate(): string {
-    // Generate 32 bytes (256 bits) of random data using Web Crypto API
-    const keyPrivateBytes = webcrypto.getRandomValues(new Uint8Array(32));
+export abstract class AbstractBlockchain implements Blockchain {
+  abstract readonly name: string;
+  abstract readonly curve: Curve | readonly Curve[];
+  abstract readonly bip44: number;
 
-    // Convert to hex string
+  readonly network: string;
+
+  constructor(options?: Options) {
+    this.network = options?.network || "mainnet";
+  }
+
+  abstract getKeyPublic(keyPrivate: string, options?: KeyOptions): string;
+  abstract getAddress(keyPublic: string, type?: string): string;
+  abstract validateAddress(address: string): boolean;
+  abstract signMessage(
+    message: string | Uint8Array,
+    keyPrivate: string,
+    options?: KeyOptions,
+  ): string;
+  abstract verifyMessage(
+    message: string | Uint8Array,
+    signature: string,
+    keyPublic: string,
+    options?: KeyOptions,
+  ): boolean;
+
+  generateKeyPrivate(): string {
+    const keyPrivateBytes = webcrypto.getRandomValues(new Uint8Array(32));
     return bytesToHex(keyPrivateBytes);
   }
 
-  /**
-   * Generates a key pair (private and public keys)
-   * This is a convenience function that combines generateKeyPrivate and getKeyPublic
-   *
-   * @param options - Optional parameters for key generation
-   * @returns A pair of cryptographic keys
-   */
-  function generateKeys(options?: KeyOptions): Keys {
-    const privateKey = generateKeyPrivate();
-    const publicKey = blockchain.getKeyPublic(privateKey, options);
+  generateKeys(options?: KeyOptions): Keys {
+    const privateKey = this.generateKeyPrivate();
+    const publicKey = this.getKeyPublic(privateKey, options);
 
     return {
       keys: {
@@ -50,42 +48,20 @@ export function useBlockchain(blockchain: BlockchainImplementation): Blockchain 
     };
   }
 
-  /**
-   * Generates a complete wallet (private key, public key, and address)
-   * This is a convenience function that combines generateKeys and getAddress
-   *
-   * @param options - Optional parameters for key generation
-   * @param addressType - Optional address type for blockchains with multiple address formats
-   * @returns A complete wallet with keys and address
-   */
-  function generateWallet(options?: KeyOptions, addressType?: AddressType): Wallet {
-    const keys = generateKeys(options);
-    const address = blockchain.getAddress(keys.keys.public, addressType);
+  generateWallet(options?: KeyOptions, addressType?: AddressType): Wallet {
+    const keys = this.generateKeys(options);
+    const address = this.getAddress(keys.keys.public, addressType);
 
     return {
       ...keys,
       address,
     };
   }
+}
 
-  const response: Blockchain = {
-    name: blockchain.name,
-    curve: blockchain.curve,
-    network: blockchain.network,
-    bip44: blockchain.bip44,
-    generateKeyPrivate,
-    getKeyPublic: blockchain.getKeyPublic,
-    getAddress: blockchain.getAddress,
-    generateKeys,
-    generateWallet,
-    signMessage: blockchain.signMessage,
-    verifyMessage: blockchain.verifyMessage,
-  };
-
-  // Add address validation if blockchain implements it
-  if (blockchain.validateAddress) {
-    response.validateAddress = blockchain.validateAddress;
-  }
-
-  return response satisfies Blockchain;
+/**
+ * Returns a concrete blockchain instance through the unified public API.
+ */
+export function useBlockchain<T extends AbstractBlockchain>(blockchain: T): T {
+  return blockchain;
 }

--- a/src/blockchains/AGENTS.md
+++ b/src/blockchains/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## OVERVIEW
 
-Lazy-loaded factory modules. Each file exports one `default function` returning `BlockchainImplementation`.
+Lazy-loaded class modules. Each file exports a named concrete class and the same class as its default export.
 
 ## CHAIN FAMILIES
 
@@ -15,27 +15,25 @@ Lazy-loaded factory modules. Each file exports one `default function` returning 
 
 ## ADDING A NEW CHAIN
 
-1. Create `src/blockchains/<name>.ts` exporting `default function <name>(options?: Options)`
-2. Implement: `getKeyPublic`, `getAddress`, `validateAddress`, `signMessage`, `verifyMessage`
-3. Return with `satisfies BlockchainImplementation` (not `: BlockchainImplementation`)
-4. Register in `src/_blockchains.ts`: `<name>: lazy(() => import('./blockchains/<name>'))`
+1. Create `src/blockchains/<name>.ts` with `class Name extends AbstractBlockchain`
+2. Implement `name`, `curve`, `bip44`, `getKeyPublic`, `getAddress`, `validateAddress`, `signMessage`, and `verifyMessage`
+3. Export the class by name and as the default export
+4. Register it in `src/_blockchains.ts`: `<name>: lazy(() => import("./blockchains/<name>.ts"))`
 5. Create `test/blockchains/<name>.test.ts` using fixtures from `test/fixtures.ts`
-6. For EVM chains: use `createEVMBlockchain()` from `utils/evm.ts` (3 lines total)
+6. For EVM chains, extend `AbstractEVMBlockchain` and provide only `name` and `bip44`
 
 ## PATTERNS
 
-- **EVM shortcut** - `ethereum.ts` and `base.ts` are ~20 lines each, delegating to `createEVMBlockchain()`
-- **Network params** - chains with testnet support (bitcoin, tron, cardano) define `networkParams` record keyed by network name
+- **EVM base class** - `Ethereum` and `Base` extend `AbstractEVMBlockchain`, which owns their shared key, address, validation, and signing behavior
+- **Network params** - chains with testnet support (bitcoin, tron, cardano) define a `NETWORK_PARAMS` record keyed by network name
 - **BIP44 coin type** - every chain sets `bip44` from `BIP44` enum or SLIP-0044 number
 - **SUI dual-curve** - `getKeyPublic` and `signMessage` check `options.scheme` to pick ed25519 or secp256k1
 
 ## COMPLEXITY
 
-| Chain          | Lines | Why                                                                         |
-| -------------- | ----- | --------------------------------------------------------------------------- |
-| bitcoin        | 175   | 5 address formats (legacy, p2sh, segwit, p2wsh, taproot) + testnet variants |
-| cardano        | 199   | Custom address encoding (prefix + base58 key hash) with 3 address types     |
-| sui            | 151   | Dual curve support, scheme-based dispatch in 4 methods                      |
-| tron           | 118   | Custom Keccak + base58check encoding                                        |
-| solana, aptos  | ~95   | Straightforward single-curve implementations                                |
-| ethereum, base | ~22   | EVM factory delegates everything                                            |
+- **Bitcoin** - five address formats (legacy, p2sh, segwit, p2wsh, taproot) plus testnet variants
+- **Cardano** - custom address encoding with three address types and centralized network parameters
+- **SUI** - dual-curve support with scheme-based dispatch
+- **TRON** - custom Keccak and Base58Check encoding
+- **Solana and Aptos** - straightforward single-curve subclasses
+- **Ethereum and Base** - minimal `AbstractEVMBlockchain` subclasses

--- a/src/blockchains/aptos.ts
+++ b/src/blockchains/aptos.ts
@@ -1,54 +1,28 @@
 import { sha3_256 } from "@noble/hashes/sha3.js";
 import { hexToBytes } from "@noble/hashes/utils.js";
-import { generateKeyPublic as getKeyPublic } from "../utils/ed25519.ts";
-import { validateAddressHex, addSchemeByte, createPrefixedAddress } from "../utils/address.ts";
+import { AbstractBlockchain } from "../blockchain.ts";
+import { addSchemeByte, createPrefixedAddress, validateAddressHex } from "../utils/address.ts";
+import { generateKeyPublic } from "../utils/ed25519.ts";
 import { ed25519SignMessage, ed25519VerifyMessage } from "../utils/ed25519-chains.ts";
-import type { Curve, Options, BlockchainImplementation, KeyOptions } from "../types.ts";
+import type { Curve, KeyOptions } from "../types.ts";
 
-/**
- * Aptos blockchain implementation
- *
- * @param options - Optional configuration parameters
- * @param options.network - Network to use (mainnet, testnet, etc.)
- * @returns An object implementing the Blockchain interface for Aptos
- */
-export default function aptos(options?: Options) {
-  const name = "aptos";
-  const curve: Curve = "ed25519";
-  const network = options?.network || "mainnet";
-  const bip44 = 637; // SLIP-0044 index for Aptos
+/** Aptos blockchain implementation. */
+export class Aptos extends AbstractBlockchain {
+  override readonly name = "aptos";
+  override readonly curve: Curve = "ed25519";
+  override readonly bip44 = 637;
 
-  /**
-   * Get Aptos address from public key
-   * Aptos address is the 32-byte SHA3-256 hash of the public key concatenated with a single byte 0x00
-   * The address format is the same for both mainnet and testnet
-   *
-   * @param keyPublic - The public key as a hex string
-   * @returns Aptos address (hex string)
-   */
-  function getAddress(keyPublic: string): string {
-    // Convert hex public key to bytes
-    const keyPublicBytes = hexToBytes(keyPublic);
-
-    // Concatenate with scheme identifier byte (0x00 for single Ed25519)
-    const dataToHash = addSchemeByte(keyPublicBytes, 0x00, false);
-
-    // Hash with SHA3-256
-    const addressBytes = sha3_256(dataToHash);
-
-    // Return as hex string with 0x prefix
-    return createPrefixedAddress(addressBytes);
+  override getKeyPublic(keyPrivate: string, _options?: KeyOptions): string {
+    return generateKeyPublic(keyPrivate);
   }
 
-  /**
-   * Validate an Aptos address
-   * Aptos addresses are hex-encoded 32-byte values starting with '0x'
-   * The validation is the same for both mainnet and testnet
-   *
-   * @param address - The address to validate
-   * @returns Whether the address is valid
-   */
-  function validateAddress(address: string): boolean {
+  override getAddress(keyPublic: string): string {
+    const keyPublicBytes = hexToBytes(keyPublic);
+    const dataToHash = addSchemeByte(keyPublicBytes, 0x00, false);
+    return createPrefixedAddress(sha3_256(dataToHash));
+  }
+
+  override validateAddress(address: string): boolean {
     try {
       return validateAddressHex(address, {
         prefix: "0x",
@@ -60,15 +34,7 @@ export default function aptos(options?: Options) {
     }
   }
 
-  /**
-   * Signs a message using Ed25519 for Aptos
-   *
-   * @param message - The message to sign
-   * @param keyPrivate - The private key
-   * @param options - Optional parameters
-   * @returns The signature as a hex string
-   */
-  function signMessage(
+  override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
     options?: KeyOptions,
@@ -76,16 +42,7 @@ export default function aptos(options?: Options) {
     return ed25519SignMessage(message, keyPrivate, options);
   }
 
-  /**
-   * Verifies a message signature for Aptos
-   *
-   * @param message - The original message
-   * @param signature - The signature to verify
-   * @param keyPublic - The public key
-   * @param options - Optional parameters
-   * @returns Whether the signature is valid
-   */
-  function verifyMessage(
+  override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
@@ -93,16 +50,6 @@ export default function aptos(options?: Options) {
   ): boolean {
     return ed25519VerifyMessage(message, signature, keyPublic, options);
   }
-
-  return {
-    name,
-    curve,
-    network,
-    bip44,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-    signMessage,
-    verifyMessage,
-  } satisfies BlockchainImplementation;
 }
+
+export default Aptos;

--- a/src/blockchains/base.ts
+++ b/src/blockchains/base.ts
@@ -1,23 +1,10 @@
-import { createEVMBlockchain } from "../utils/evm.ts";
-import type { Options, BlockchainImplementation } from "../types.ts";
+import { AbstractEVMBlockchain } from "../utils/evm.ts";
 import { BIP44 } from "../utils/bip44/index.ts";
 
-/**
- * Base blockchain implementation
- * Uses the EVM implementation for address generation and validation
- * Base is an L2 solution for Ethereum that uses the same address format
- *
- * @param options - Optional configuration parameters
- * @param options.network - Network to use (mainnet, testnet, etc.)
- * @returns An object implementing the Blockchain interface for Base
- */
-export default function base(options?: Options) {
-  const name = "base";
-  const bip44 = BIP44.ETHEREUM; // Base uses Ethereum's coin type as an L2
-  const network = options?.network || "mainnet";
-
-  return createEVMBlockchain(name, {
-    network,
-    bip44,
-  }) satisfies BlockchainImplementation;
+/** Base blockchain implementation. */
+export class Base extends AbstractEVMBlockchain {
+  override readonly name = "base";
+  override readonly bip44 = BIP44.ETHEREUM;
 }
+
+export default Base;

--- a/src/blockchains/bitcoin.ts
+++ b/src/blockchains/bitcoin.ts
@@ -1,195 +1,138 @@
-import { generateKeyPublic as getKeyPublic } from "../utils/secp256k1.ts";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { AbstractBlockchain } from "../blockchain.ts";
 import {
   generateAddressLegacy,
-  validateAddressLegacy,
   generateAddressP2SH,
-  validateAddressP2SH,
   generateAddressSegWit,
+  validateAddressLegacy,
+  validateAddressP2SH,
   validateAddressSegWit,
 } from "../utils/address.ts";
+import { generateKeyPublic } from "../utils/secp256k1.ts";
 import {
   signMessage as genericSignMessage,
   verifyMessage as genericVerifyMessage,
 } from "../utils/signing.ts";
-import { sha256 } from "@noble/hashes/sha2.js";
-import type { Curve, Options, BlockchainImplementation, KeyOptions } from "../types.ts";
+import type { Curve, KeyOptions } from "../types.ts";
 
-/**
- * Encode a number as a Bitcoin compact size (varint)
- */
-function encodeCompactSize(n: number): Uint8Array {
-  if (n < 0xfd) {
-    return new Uint8Array([n]);
+const NETWORK_PARAMS = {
+  mainnet: {
+    hrpSegWit: "bc",
+    prefixSegWitV1: "bc1p",
+    bytesVersionP2PKH: 0x00,
+    bytesVersionP2SH: 0x05,
+  },
+  testnet: {
+    hrpSegWit: "tb",
+    prefixSegWitV1: "tb1p",
+    bytesVersionP2PKH: 0x6f,
+    bytesVersionP2SH: 0xc4,
+  },
+} as const;
+
+function encodeCompactSize(value: number): Uint8Array {
+  if (value < 0xfd) return new Uint8Array([value]);
+  if (value <= 0xffff) {
+    const buffer = new Uint8Array(3);
+    buffer[0] = 0xfd;
+    buffer[1] = value & 0xff;
+    buffer[2] = (value >> 8) & 0xff;
+    return buffer;
   }
-  if (n <= 0xffff) {
-    const buf = new Uint8Array(3);
-    buf[0] = 0xfd;
-    buf[1] = n & 0xff;
-    buf[2] = (n >> 8) & 0xff;
-    return buf;
-  }
-  const buf = new Uint8Array(5);
-  buf[0] = 0xfe;
-  buf[1] = n & 0xff;
-  buf[2] = (n >> 8) & 0xff;
-  buf[3] = (n >> 16) & 0xff;
-  buf[4] = (n >> 24) & 0xff;
-  return buf;
+
+  const buffer = new Uint8Array(5);
+  buffer[0] = 0xfe;
+  buffer[1] = value & 0xff;
+  buffer[2] = (value >> 8) & 0xff;
+  buffer[3] = (value >> 16) & 0xff;
+  buffer[4] = (value >> 24) & 0xff;
+  return buffer;
 }
 
-export default function bitcoin(options?: Options) {
-  const name = "bitcoin";
-  const curve: Curve = "secp256k1";
-  const network = options?.network || "mainnet";
-  const bip44 = 0; // SLIP-0044 index for Bitcoin
+/** Bitcoin blockchain implementation. */
+export class Bitcoin extends AbstractBlockchain {
+  override readonly name = "bitcoin";
+  override readonly curve: Curve = "secp256k1";
+  override readonly bip44 = 0;
 
-  // Network-specific parameters for address generation and validation
-  const networkParams = {
-    mainnet: {
-      hrpSegWit: "bc",
-      prefixSegWitV0: "bc1q",
-      prefixSegWitV1: "bc1p",
-      bytesVersionP2PKH: 0x00,
-      bytesVersionP2SH: 0x05,
-    },
-    testnet: {
-      hrpSegWit: "tb",
-      prefixSegWitV0: "tb1q",
-      prefixSegWitV1: "tb1p",
-      bytesVersionP2PKH: 0x6f, // 111 in decimal
-      bytesVersionP2SH: 0xc4, // 196 in decimal
-    },
-  };
+  private get params() {
+    return this.network === "testnet" ? NETWORK_PARAMS.testnet : NETWORK_PARAMS.mainnet;
+  }
 
-  // Get parameters for the current network
-  const params = network === "testnet" ? networkParams.testnet : networkParams.mainnet;
+  override getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
+    return generateKeyPublic(keyPrivate, options);
+  }
 
-  /**
-   * Get Bitcoin address from public key
-   * Supports following formats:
-   * - 'legacy' (P2PKH) - addresses starting with '1' (mainnet) or 'm'/'n' (testnet)
-   * - 'p2sh' - addresses starting with '3' (mainnet) or '2' (testnet)
-   * - 'segwit' - addresses starting with 'bc1q' (mainnet) or 'tb1q' (testnet) with short data (P2WPKH)
-   * - 'p2wsh' - addresses starting with 'bc1q' (mainnet) or 'tb1q' (testnet) with longer data (P2WSH)
-   * - 'taproot' - addresses starting with 'bc1p' (mainnet) or 'tb1p' (testnet) (SegWit v1)
-   *
-   * @param keyPublic - The public key as a hex string
-   * @param type - Address type (legacy, p2sh, segwit, p2wsh, or taproot)
-   * @returns Bitcoin address
-   */
-  function getAddress(keyPublic: string, type = "legacy"): string {
-    const addressType = type;
-
-    // Handle SegWit address types
-    if (["segwit", "p2wsh", "taproot"].includes(addressType)) {
+  override getAddress(keyPublic: string, type = "legacy"): string {
+    if (["segwit", "p2wsh", "taproot"].includes(type)) {
       const segwitOptions = {
-        hrp: params.hrpSegWit,
-        witnessVersion: addressType === "taproot" ? 1 : 0,
+        hrp: this.params.hrpSegWit,
+        witnessVersion: type === "taproot" ? 1 : 0,
       };
-
-      const segwitType = addressType === "p2wsh" ? "p2wsh" : "p2wpkh";
+      const segwitType = type === "p2wsh" ? "p2wsh" : "p2wpkh";
       return generateAddressSegWit(keyPublic, segwitOptions, segwitType);
     }
 
-    // Handle P2SH address type
-    if (addressType === "p2sh") {
+    if (type === "p2sh") {
       return generateAddressP2SH(keyPublic, {
-        bytesVersion: params.bytesVersionP2SH,
+        bytesVersion: this.params.bytesVersionP2SH,
       });
     }
 
-    // Default to legacy (P2PKH)
     return generateAddressLegacy(keyPublic, {
-      bytesVersion: params.bytesVersionP2PKH,
+      bytesVersion: this.params.bytesVersionP2PKH,
     });
   }
 
-  /**
-   * Validate a Bitcoin address
-   * Supports:
-   * - Legacy (P2PKH) addresses starting with '1' (mainnet) or 'm'/'n' (testnet)
-   * - P2SH addresses starting with '3' (mainnet) or '2' (testnet)
-   * - SegWit v0 P2WPKH (bech32) addresses starting with 'bc1q' (mainnet) or 'tb1q' (testnet) with 20-byte program
-   * - SegWit v0 P2WSH (bech32) addresses starting with 'bc1q' (mainnet) or 'tb1q' (testnet) with 32-byte program
-   * - SegWit v1 (bech32m) addresses starting with 'bc1p' (mainnet) or 'tb1p' (testnet) (Taproot)
-   *
-   * @param address - The address to validate
-   * @returns Whether the address is valid
-   */
-  function validateAddress(address: string): boolean {
-    // Check for SegWit addresses
-    const hrpSegWit = params.hrpSegWit;
-    const segwitPrefix = hrpSegWit + "1";
-
+  override validateAddress(address: string): boolean {
+    const segwitPrefix = this.params.hrpSegWit + "1";
     if (address.startsWith(segwitPrefix)) {
-      const prefixV1 = params.prefixSegWitV1;
-
-      // Check for Taproot address (witness version 1)
-      if (address.startsWith(prefixV1)) {
-        return validateAddressSegWit(address, { hrp: hrpSegWit, witnessVersion: 1 });
+      if (address.startsWith(this.params.prefixSegWitV1)) {
+        return validateAddressSegWit(address, {
+          hrp: this.params.hrpSegWit,
+          witnessVersion: 1,
+        });
       }
-
-      // Handle SegWit v0 addresses (bech32)
-      return validateAddressSegWit(address, { hrp: hrpSegWit, witnessVersion: 0 });
+      return validateAddressSegWit(address, {
+        hrp: this.params.hrpSegWit,
+        witnessVersion: 0,
+      });
     }
 
-    // For mainnet, look for '3' prefix for P2SH
-    if (network === "mainnet" && address.startsWith("3")) {
-      return validateAddressP2SH(address, { bytesVersion: params.bytesVersionP2SH });
+    if (this.network === "mainnet" && address.startsWith("3")) {
+      return validateAddressP2SH(address, { bytesVersion: this.params.bytesVersionP2SH });
     }
-
-    // For testnet, look for '2' prefix for P2SH
-    if (network === "testnet" && address.startsWith("2")) {
-      return validateAddressP2SH(address, { bytesVersion: params.bytesVersionP2SH });
+    if (this.network === "testnet" && address.startsWith("2")) {
+      return validateAddressP2SH(address, { bytesVersion: this.params.bytesVersionP2SH });
     }
-
-    // For mainnet, legacy addresses start with '1'
-    if (network === "mainnet" && address.startsWith("1")) {
-      return validateAddressLegacy(address, { bytesVersion: params.bytesVersionP2PKH });
+    if (this.network === "mainnet" && address.startsWith("1")) {
+      return validateAddressLegacy(address, { bytesVersion: this.params.bytesVersionP2PKH });
     }
-
-    // For testnet, legacy addresses start with 'm' or 'n'
-    if (network === "testnet" && (address.startsWith("m") || address.startsWith("n"))) {
-      return validateAddressLegacy(address, { bytesVersion: params.bytesVersionP2PKH });
+    if (this.network === "testnet" && (address.startsWith("m") || address.startsWith("n"))) {
+      return validateAddressLegacy(address, { bytesVersion: this.params.bytesVersionP2PKH });
     }
-
-    // If none of the above, address is invalid for the current network
     return false;
   }
 
-  /**
-   * Hashes a message with Bitcoin's message preamble using double SHA-256
-   * Format: varint(24) + "Bitcoin Signed Message:\n" + varint(msgLen) + message
-   *
-   * @param message - The message to hash
-   * @returns The double SHA-256 hash of the prefixed message
-   */
-  function hashWithBitcoinPreamble(message: string | Uint8Array): Uint8Array {
-    const preamble = "\u0018Bitcoin Signed Message:\n";
+  private hashWithBitcoinPreamble(message: string | Uint8Array): Uint8Array {
+    const preambleBytes = new TextEncoder().encode("\u0018Bitcoin Signed Message:\n");
     const messageBytes = typeof message === "string" ? new TextEncoder().encode(message) : message;
-    const varint = encodeCompactSize(messageBytes.length);
-    const preambleBytes = new TextEncoder().encode(preamble);
-    const fullMessage = new Uint8Array(preambleBytes.length + varint.length + messageBytes.length);
+    const messageLength = encodeCompactSize(messageBytes.length);
+    const fullMessage = new Uint8Array(
+      preambleBytes.length + messageLength.length + messageBytes.length,
+    );
     fullMessage.set(preambleBytes);
-    fullMessage.set(varint, preambleBytes.length);
-    fullMessage.set(messageBytes, preambleBytes.length + varint.length);
+    fullMessage.set(messageLength, preambleBytes.length);
+    fullMessage.set(messageBytes, preambleBytes.length + messageLength.length);
     return sha256(sha256(fullMessage));
   }
 
-  /**
-   * Signs a message using secp256k1 with Bitcoin's message preamble
-   *
-   * @param message - The message to sign
-   * @param keyPrivate - The private key
-   * @param options - Optional parameters
-   * @returns The signature as a hex string
-   */
-  function signMessage(
+  override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
     options?: KeyOptions,
   ): string {
-    const hash = hashWithBitcoinPreamble(message);
+    const hash = this.hashWithBitcoinPreamble(message);
     return genericSignMessage(hash, keyPrivate, {
       ...options,
       curve: "secp256k1",
@@ -197,22 +140,13 @@ export default function bitcoin(options?: Options) {
     });
   }
 
-  /**
-   * Verifies a message signature for Bitcoin
-   *
-   * @param message - The original message
-   * @param signature - The signature to verify
-   * @param keyPublic - The public key
-   * @param options - Optional parameters
-   * @returns Whether the signature is valid
-   */
-  function verifyMessage(
+  override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
     options?: KeyOptions,
   ): boolean {
-    const hash = hashWithBitcoinPreamble(message);
+    const hash = this.hashWithBitcoinPreamble(message);
     try {
       return genericVerifyMessage(hash, signature, keyPublic, {
         ...options,
@@ -223,16 +157,6 @@ export default function bitcoin(options?: Options) {
       return false;
     }
   }
-
-  return {
-    name,
-    curve,
-    network,
-    bip44,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-    signMessage,
-    verifyMessage,
-  } satisfies BlockchainImplementation;
 }
+
+export default Bitcoin;

--- a/src/blockchains/cardano.ts
+++ b/src/blockchains/cardano.ts
@@ -1,75 +1,58 @@
 import { blake2b } from "@noble/hashes/blake2.js";
 import { hexToBytes } from "@noble/hashes/utils.js";
+import { bech32 } from "@scure/base";
+import { AbstractBlockchain } from "../blockchain.ts";
 import { generateKeyPublic as getEd25519KeyPublic } from "../utils/ed25519.ts";
 import { ed25519SignMessage, ed25519VerifyMessage } from "../utils/ed25519-chains.ts";
-import { bech32 } from "@scure/base";
-import type { Curve, KeyOptions, Options, BlockchainImplementation } from "../types.ts";
+import type { Curve, KeyOptions } from "../types.ts";
 
-export default function cardano(options?: Options) {
-  const name = "cardano";
-  const curve: Curve = "ed25519";
-  const network = options?.network || "mainnet";
-  const bip44 = 1815; // SLIP-0044 index for Cardano
+const ADDRESS_TYPE = {
+  BASE_PAYMENT: 0,
+  ENTERPRISE_KEY: 6,
+  REWARD_KEY: 14,
+} as const;
 
-  const networkId = network === "testnet" ? 0 : 1;
+/** Cardano blockchain implementation. */
+export class Cardano extends AbstractBlockchain {
+  override readonly name = "cardano";
+  override readonly curve: Curve = "ed25519";
+  override readonly bip44 = 1815;
 
-  const ADDRESS_TYPE = {
-    BASE_PAYMENT: 0,
-    ENTERPRISE_KEY: 6,
-    REWARD_KEY: 14,
-  };
-
-  /**
-   * Get public key from private key using Ed25519 curve
-   *
-   * @param keyPrivate - The private key as a hex string
-   * @param options - Optional parameters
-   * @returns Public key as hex string
-   */
-  function getKeyPublic(keyPrivate: string, _options?: KeyOptions): string {
+  override getKeyPublic(keyPrivate: string, _options?: KeyOptions): string {
     return getEd25519KeyPublic(keyPrivate);
   }
 
-  /**
-   * Get Cardano key hash from public key
-   *
-   * @param keyPublic - Public key as hex string
-   * @returns Hashed key bytes
-   */
-  function getKeyHash(keyPublic: string): Uint8Array {
-    // Convert public key to bytes
-    const keyPublicBytes = hexToBytes(keyPublic);
-
-    // Hash the public key with blake2b-224 for Cardano addresses
-    return blake2b(keyPublicBytes, { dkLen: 28 }); // 28 bytes = 224 bits
+  private getKeyHash(keyPublic: string): Uint8Array {
+    return blake2b(hexToBytes(keyPublic), { dkLen: 28 });
   }
 
-  function encodeAddress(hrp: string, header: number, payload: Uint8Array): string {
+  private encodeAddress(hrp: string, header: number, payload: Uint8Array): string {
     const bytes = new Uint8Array(1 + payload.length);
     bytes[0] = header;
     bytes.set(payload, 1);
     return bech32.encode(hrp, bech32.toWords(bytes), false);
   }
 
-  function header(addressType: number): number {
+  private header(addressType: number): number {
+    const networkId = this.network === "testnet" ? 0 : 1;
     return (addressType << 4) | networkId;
   }
 
-  function getAddress(keyPublic: string, type?: string): string {
-    const keyHash = getKeyHash(keyPublic);
+  override getAddress(keyPublic: string, type?: string): string {
+    const keyHash = this.getKeyHash(keyPublic);
 
     if (type === "stake") {
-      return encodeAddress(
-        network === "testnet" ? "stake_test" : "stake",
-        header(ADDRESS_TYPE.REWARD_KEY),
+      return this.encodeAddress(
+        this.network === "testnet" ? "stake_test" : "stake",
+        this.header(ADDRESS_TYPE.REWARD_KEY),
         keyHash,
       );
     }
 
     if (type === "enterprise") {
-      return encodeAddress(
-        network === "testnet" ? "addr_test" : "addr",
-        header(ADDRESS_TYPE.ENTERPRISE_KEY),
+      return this.encodeAddress(
+        this.network === "testnet" ? "addr_test" : "addr",
+        this.header(ADDRESS_TYPE.ENTERPRISE_KEY),
         keyHash,
       );
     }
@@ -77,31 +60,31 @@ export default function cardano(options?: Options) {
     const basePayload = new Uint8Array(keyHash.length * 2);
     basePayload.set(keyHash);
     basePayload.set(keyHash, keyHash.length);
-    return encodeAddress(
-      network === "testnet" ? "addr_test" : "addr",
-      header(ADDRESS_TYPE.BASE_PAYMENT),
+    return this.encodeAddress(
+      this.network === "testnet" ? "addr_test" : "addr",
+      this.header(ADDRESS_TYPE.BASE_PAYMENT),
       basePayload,
     );
   }
 
-  function validateAddress(address: string): boolean {
+  override validateAddress(address: string): boolean {
     try {
       const decoded = bech32.decode(address, false);
       const bytes = bech32.fromWords(decoded.words);
-      if (bytes.length === 0) return false;
+      const headerByte = bytes[0];
+      if (headerByte === undefined) return false;
 
-      const addressNetwork = bytes[0]! & 0x0f;
-      const addressType = bytes[0]! >> 4;
-      if (addressNetwork !== networkId) return false;
+      const expectedNetwork = this.network === "testnet" ? 0 : 1;
+      const addressNetwork = headerByte & 0x0f;
+      const addressType = headerByte >> 4;
+      if (addressNetwork !== expectedNetwork) return false;
 
-      if (decoded.prefix === (network === "testnet" ? "stake_test" : "stake")) {
+      if (decoded.prefix === (this.network === "testnet" ? "stake_test" : "stake")) {
         return addressType === ADDRESS_TYPE.REWARD_KEY && bytes.length === 29;
       }
-
-      if (decoded.prefix !== (network === "testnet" ? "addr_test" : "addr")) {
+      if (decoded.prefix !== (this.network === "testnet" ? "addr_test" : "addr")) {
         return false;
       }
-
       if (addressType === ADDRESS_TYPE.BASE_PAYMENT) return bytes.length === 57;
       if (addressType === ADDRESS_TYPE.ENTERPRISE_KEY) return bytes.length === 29;
       return false;
@@ -110,15 +93,7 @@ export default function cardano(options?: Options) {
     }
   }
 
-  /**
-   * Signs a message using Ed25519 for Cardano
-   *
-   * @param message - The message to sign
-   * @param keyPrivate - The private key
-   * @param options - Optional parameters
-   * @returns The signature as a hex string
-   */
-  function signMessage(
+  override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
     options?: KeyOptions,
@@ -126,16 +101,7 @@ export default function cardano(options?: Options) {
     return ed25519SignMessage(message, keyPrivate, options);
   }
 
-  /**
-   * Verifies a message signature for Cardano
-   *
-   * @param message - The original message
-   * @param signature - The signature to verify
-   * @param keyPublic - The public key
-   * @param options - Optional parameters
-   * @returns Whether the signature is valid
-   */
-  function verifyMessage(
+  override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
@@ -143,16 +109,6 @@ export default function cardano(options?: Options) {
   ): boolean {
     return ed25519VerifyMessage(message, signature, keyPublic, options);
   }
-
-  return {
-    name,
-    curve,
-    network,
-    bip44,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-    signMessage,
-    verifyMessage,
-  } satisfies BlockchainImplementation;
 }
+
+export default Cardano;

--- a/src/blockchains/cardano.ts
+++ b/src/blockchains/cardano.ts
@@ -12,11 +12,28 @@ const ADDRESS_TYPE = {
   REWARD_KEY: 14,
 } as const;
 
+const NETWORK_PARAMS = {
+  mainnet: {
+    hrpAddress: "addr",
+    hrpStake: "stake",
+    networkId: 1,
+  },
+  testnet: {
+    hrpAddress: "addr_test",
+    hrpStake: "stake_test",
+    networkId: 0,
+  },
+} as const;
+
 /** Cardano blockchain implementation. */
 export class Cardano extends AbstractBlockchain {
   override readonly name = "cardano";
   override readonly curve: Curve = "ed25519";
   override readonly bip44 = 1815;
+
+  private get params() {
+    return this.network === "testnet" ? NETWORK_PARAMS.testnet : NETWORK_PARAMS.mainnet;
+  }
 
   override getKeyPublic(keyPrivate: string, _options?: KeyOptions): string {
     return getEd25519KeyPublic(keyPrivate);
@@ -34,8 +51,7 @@ export class Cardano extends AbstractBlockchain {
   }
 
   private header(addressType: number): number {
-    const networkId = this.network === "testnet" ? 0 : 1;
-    return (addressType << 4) | networkId;
+    return (addressType << 4) | this.params.networkId;
   }
 
   override getAddress(keyPublic: string, type?: string): string {
@@ -43,7 +59,7 @@ export class Cardano extends AbstractBlockchain {
 
     if (type === "stake") {
       return this.encodeAddress(
-        this.network === "testnet" ? "stake_test" : "stake",
+        this.params.hrpStake,
         this.header(ADDRESS_TYPE.REWARD_KEY),
         keyHash,
       );
@@ -51,7 +67,7 @@ export class Cardano extends AbstractBlockchain {
 
     if (type === "enterprise") {
       return this.encodeAddress(
-        this.network === "testnet" ? "addr_test" : "addr",
+        this.params.hrpAddress,
         this.header(ADDRESS_TYPE.ENTERPRISE_KEY),
         keyHash,
       );
@@ -61,7 +77,7 @@ export class Cardano extends AbstractBlockchain {
     basePayload.set(keyHash);
     basePayload.set(keyHash, keyHash.length);
     return this.encodeAddress(
-      this.network === "testnet" ? "addr_test" : "addr",
+      this.params.hrpAddress,
       this.header(ADDRESS_TYPE.BASE_PAYMENT),
       basePayload,
     );
@@ -74,15 +90,15 @@ export class Cardano extends AbstractBlockchain {
       const headerByte = bytes[0];
       if (headerByte === undefined) return false;
 
-      const expectedNetwork = this.network === "testnet" ? 0 : 1;
+      const expectedNetwork = this.params.networkId;
       const addressNetwork = headerByte & 0x0f;
       const addressType = headerByte >> 4;
       if (addressNetwork !== expectedNetwork) return false;
 
-      if (decoded.prefix === (this.network === "testnet" ? "stake_test" : "stake")) {
+      if (decoded.prefix === this.params.hrpStake) {
         return addressType === ADDRESS_TYPE.REWARD_KEY && bytes.length === 29;
       }
-      if (decoded.prefix !== (this.network === "testnet" ? "addr_test" : "addr")) {
+      if (decoded.prefix !== this.params.hrpAddress) {
         return false;
       }
       if (addressType === ADDRESS_TYPE.BASE_PAYMENT) return bytes.length === 57;

--- a/src/blockchains/ethereum.ts
+++ b/src/blockchains/ethereum.ts
@@ -1,22 +1,10 @@
-import { createEVMBlockchain } from "../utils/evm.ts";
-import type { Options, BlockchainImplementation } from "../types.ts";
+import { AbstractEVMBlockchain } from "../utils/evm.ts";
 import { BIP44 } from "../utils/bip44/index.ts";
 
-/**
- * Ethereum blockchain implementation
- * Uses the EVM implementation for address generation and validation
- *
- * @param options - Optional configuration parameters
- * @param options.network - Network to use (mainnet, testnet, etc.)
- * @returns An object implementing the Blockchain interface for Ethereum
- */
-export default function ethereum(options?: Options) {
-  const name = "ethereum";
-  const bip44 = BIP44.ETHEREUM;
-  const network = options?.network || "mainnet";
-
-  return createEVMBlockchain(name, {
-    network,
-    bip44,
-  }) satisfies BlockchainImplementation;
+/** Ethereum blockchain implementation. */
+export class Ethereum extends AbstractEVMBlockchain {
+  override readonly name = "ethereum";
+  override readonly bip44 = BIP44.ETHEREUM;
 }
+
+export default Ethereum;

--- a/src/blockchains/solana.ts
+++ b/src/blockchains/solana.ts
@@ -1,66 +1,34 @@
-import { base58 } from "@scure/base";
 import { hexToBytes } from "@noble/hashes/utils.js";
-import { generateKeyPublic as getKeyPublic } from "../utils/ed25519.ts";
+import { base58 } from "@scure/base";
+import { AbstractBlockchain } from "../blockchain.ts";
+import { generateKeyPublic } from "../utils/ed25519.ts";
 import { solanaSignMessage, solanaVerifyMessage } from "../utils/ed25519-chains.ts";
-import type { Curve, Options, BlockchainImplementation, KeyOptions } from "../types.ts";
 import { BIP44 } from "../utils/bip44/index.ts";
+import type { Curve, KeyOptions } from "../types.ts";
 
-/**
- * Solana blockchain implementation
- *
- * @param options - Optional configuration parameters
- * @param options.network - Network to use (mainnet, testnet, etc.)
- * @returns An object implementing the Blockchain interface for Solana
- */
-export default function solana(options?: Options) {
-  const name = "solana";
-  const curve: Curve = "ed25519";
-  const network = options?.network || "mainnet";
-  const bip44 = BIP44.SOLANA;
+/** Solana blockchain implementation. */
+export class Solana extends AbstractBlockchain {
+  override readonly name = "solana";
+  override readonly curve: Curve = "ed25519";
+  override readonly bip44 = BIP44.SOLANA;
 
-  /**
-   * Get Solana address from public key
-   * Solana addresses are just the base58-encoded public key
-   * The address format is the same for both mainnet and testnet
-   *
-   * @param keyPublic - The public key as a hex string
-   * @returns Solana address (base58 encoded public key)
-   */
-  function getAddress(keyPublic: string): string {
-    // For Solana, the address is the same as the public key
-    // We just need to convert from hex to base58
-    const keyBytes = hexToBytes(keyPublic);
-    return base58.encode(keyBytes);
+  override getKeyPublic(keyPrivate: string, _options?: KeyOptions): string {
+    return generateKeyPublic(keyPrivate);
   }
 
-  /**
-   * Validate a Solana address
-   * Solana addresses are base58-encoded 32-byte Ed25519 public keys
-   * The validation is the same for both mainnet and testnet
-   *
-   * @param address - The address to validate
-   * @returns Whether the address is valid
-   */
-  function validateAddress(address: string): boolean {
+  override getAddress(keyPublic: string): string {
+    return base58.encode(hexToBytes(keyPublic));
+  }
+
+  override validateAddress(address: string): boolean {
     try {
-      // Try to decode as base58
-      const decoded = base58.decode(address);
-      // Solana addresses are 32 bytes (Ed25519 public key)
-      return decoded.length === 32;
+      return base58.decode(address).length === 32;
     } catch {
       return false;
     }
   }
 
-  /**
-   * Signs a message using Ed25519 for Solana
-   *
-   * @param message - The message to sign
-   * @param keyPrivate - The private key
-   * @param options - Optional parameters
-   * @returns The signature as a hex string
-   */
-  function signMessage(
+  override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
     _options?: KeyOptions,
@@ -68,16 +36,7 @@ export default function solana(options?: Options) {
     return solanaSignMessage(message, keyPrivate);
   }
 
-  /**
-   * Verifies a message signature for Solana
-   *
-   * @param message - The original message
-   * @param signature - The signature to verify
-   * @param keyPublic - The public key
-   * @param options - Optional parameters
-   * @returns Whether the signature is valid
-   */
-  function verifyMessage(
+  override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
@@ -85,16 +44,6 @@ export default function solana(options?: Options) {
   ): boolean {
     return solanaVerifyMessage(message, signature, keyPublic);
   }
-
-  return {
-    name,
-    curve,
-    network,
-    bip44,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-    signMessage,
-    verifyMessage,
-  } satisfies BlockchainImplementation;
 }
+
+export default Solana;

--- a/src/blockchains/solana.ts
+++ b/src/blockchains/solana.ts
@@ -2,7 +2,7 @@ import { hexToBytes } from "@noble/hashes/utils.js";
 import { base58 } from "@scure/base";
 import { AbstractBlockchain } from "../blockchain.ts";
 import { generateKeyPublic } from "../utils/ed25519.ts";
-import { solanaSignMessage, solanaVerifyMessage } from "../utils/ed25519-chains.ts";
+import { ed25519SignMessage, ed25519VerifyMessage } from "../utils/ed25519-chains.ts";
 import { BIP44 } from "../utils/bip44/index.ts";
 import type { Curve, KeyOptions } from "../types.ts";
 
@@ -31,18 +31,22 @@ export class Solana extends AbstractBlockchain {
   override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
-    _options?: KeyOptions,
+    options?: KeyOptions,
   ): string {
-    return solanaSignMessage(message, keyPrivate);
+    return ed25519SignMessage(message, keyPrivate, options);
   }
 
   override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
-    _options?: KeyOptions,
+    options?: KeyOptions,
   ): boolean {
-    return solanaVerifyMessage(message, signature, keyPublic);
+    try {
+      return ed25519VerifyMessage(message, signature, keyPublic, options);
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/src/blockchains/sui.ts
+++ b/src/blockchains/sui.ts
@@ -6,7 +6,7 @@ import { generateKeyPublic as getEd25519KeyPublic } from "../utils/ed25519.ts";
 import { ed25519SignMessage, ed25519VerifyMessage } from "../utils/ed25519-chains.ts";
 import { evmSignMessage, evmVerifyMessage } from "../utils/evm.ts";
 import { generateKeyPublic as getSecp256k1KeyPublic } from "../utils/secp256k1.ts";
-import type { KeyOptions } from "../types.ts";
+import type { AddressType, KeyOptions, Wallet } from "../types.ts";
 
 const CURVES = ["ed25519", "secp256k1"] as const;
 const SIGNATURE_SCHEME_FLAGS = {
@@ -21,6 +21,18 @@ export class Sui extends AbstractBlockchain {
   override readonly name = "sui";
   override readonly curve = CURVES;
   override readonly bip44 = 784;
+
+  override generateWallet(options?: KeyOptions, addressType?: AddressType): Wallet {
+    const scheme = addressType ?? options?.scheme;
+    const keyOptions =
+      addressType === undefined
+        ? options
+        : {
+            ...options,
+            scheme: addressType,
+          };
+    return super.generateWallet(keyOptions, scheme);
+  }
 
   override getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
     const scheme = options?.scheme ?? "ed25519";

--- a/src/blockchains/sui.ts
+++ b/src/blockchains/sui.ts
@@ -1,95 +1,46 @@
 import { blake2b } from "@noble/hashes/blake2.js";
 import { hexToBytes } from "@noble/hashes/utils.js";
+import { AbstractBlockchain } from "../blockchain.ts";
+import { addSchemeByte, createPrefixedAddress, validateAddressHex } from "../utils/address.ts";
 import { generateKeyPublic as getEd25519KeyPublic } from "../utils/ed25519.ts";
-import { generateKeyPublic as getSecp256k1KeyPublic } from "../utils/secp256k1.ts";
-import { validateAddressHex, addSchemeByte, createPrefixedAddress } from "../utils/address.ts";
 import { ed25519SignMessage, ed25519VerifyMessage } from "../utils/ed25519-chains.ts";
 import { evmSignMessage, evmVerifyMessage } from "../utils/evm.ts";
-import type { Curve, KeyOptions, Options, BlockchainImplementation } from "../types.ts";
+import { generateKeyPublic as getSecp256k1KeyPublic } from "../utils/secp256k1.ts";
+import type { KeyOptions } from "../types.ts";
 
-/**
- * Sui blockchain implementation
- *
- * @param options - Optional configuration parameters
- * @param options.network - Network to use (mainnet, testnet, devnet)
- * @returns An object implementing the Blockchain interface for Sui
- */
-export default function sui(options?: Options) {
-  const name = "sui";
-  const curve: Curve[] = ["ed25519", "secp256k1"];
-  const network = options?.network || "mainnet";
-  const bip44 = 784; // SLIP-0044 index for Sui
+const CURVES = ["ed25519", "secp256k1"] as const;
+const SIGNATURE_SCHEME_FLAGS = {
+  ED25519: 0x00,
+  SECP256K1: 0x01,
+  SECP256R1: 0x02,
+  MULTISIG: 0x03,
+} as const;
 
-  /**
-   * Flag bytes for different signature schemes in Sui
-   */
-  const SIGNATURE_SCHEME_FLAGS = {
-    ED25519: 0x00,
-    SECP256K1: 0x01,
-    SECP256R1: 0x02,
-    MULTISIG: 0x03,
-  };
+/** Sui blockchain implementation. */
+export class Sui extends AbstractBlockchain {
+  override readonly name = "sui";
+  override readonly curve = CURVES;
+  override readonly bip44 = 784;
 
-  /**
-   * Get Sui public key with specified scheme (defaults to Ed25519)
-   *
-   * @param keyPrivate - The private key as a hex string
-   * @param scheme - Signature scheme (ed25519, secp256k1)
-   * @returns Public key as hex string
-   */
-  function getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
-    // Extract scheme from options or use default 'ed25519'
-    const scheme = options?.scheme || "ed25519";
-
+  override getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
+    const scheme = options?.scheme ?? "ed25519";
     if (scheme.toLowerCase() === "secp256k1") {
       return getSecp256k1KeyPublic(keyPrivate, { compressed: true });
     }
-
-    // Default to Ed25519
     return getEd25519KeyPublic(keyPrivate);
   }
 
-  /**
-   * Get Sui address from public key
-   * Sui address is derived by hashing signature scheme flag + public key bytes using BLAKE2b
-   * The address format is the same for mainnet, testnet, and devnet
-   *
-   * @param keyPublic - The public key as a hex string
-   * @param scheme - Signature scheme (ed25519, secp256k1)
-   * @returns Sui address (hex encoded BLAKE2b hash with 0x prefix)
-   */
-  function getAddress(keyPublic: string, type?: string): string {
-    // Convert public key to bytes
+  override getAddress(keyPublic: string, type?: string): string {
     const keyPublicBytes = hexToBytes(keyPublic);
-
-    // Determine flag byte based on scheme
     const flagByte =
       type?.toLowerCase() === "secp256k1"
         ? SIGNATURE_SCHEME_FLAGS.SECP256K1
         : SIGNATURE_SCHEME_FLAGS.ED25519;
-
-    // Create input for hashing: flag byte + public key
     const input = addSchemeByte(keyPublicBytes, flagByte, true);
-
-    // Hash with BLAKE2b-256
-    const hash = blake2b(input, { dkLen: 32 }); // 32 bytes = 256 bits
-
-    // Sui address is just the hex representation of the hash
-    return createPrefixedAddress(hash);
+    return createPrefixedAddress(blake2b(input, { dkLen: 32 }));
   }
 
-  /**
-   * Validate a Sui address
-   * Valid Sui addresses:
-   * - Start with '0x'
-   * - Are 66 characters long (0x + 64 hex chars)
-   * - Contain only valid hex characters
-   * The validation is the same for mainnet, testnet, and devnet
-   *
-   * @param address - The address to validate
-   * @returns Whether the address is valid
-   */
-  function validateAddress(address: string): boolean {
+  override validateAddress(address: string): boolean {
     return validateAddressHex(address, {
       prefix: "0x",
       length: 64,
@@ -97,65 +48,28 @@ export default function sui(options?: Options) {
     });
   }
 
-  /**
-   * Signs a message using the appropriate algorithm for Sui based on the scheme
-   *
-   * @param message - The message to sign
-   * @param keyPrivate - The private key
-   * @param options - Optional parameters including scheme
-   * @returns The signature as a hex string
-   */
-  function signMessage(
+  override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
     options?: KeyOptions,
   ): string {
-    // Extract scheme from options or use default 'ed25519'
-    const scheme = options?.scheme || "ed25519";
-
-    if (scheme.toLowerCase() === "secp256k1") {
-      return evmSignMessage(message, keyPrivate, options);
-    }
-
-    // Default to Ed25519
-    return ed25519SignMessage(message, keyPrivate, options);
+    const scheme = options?.scheme ?? "ed25519";
+    return scheme.toLowerCase() === "secp256k1"
+      ? evmSignMessage(message, keyPrivate, options)
+      : ed25519SignMessage(message, keyPrivate, options);
   }
 
-  /**
-   * Verifies a message signature for Sui based on the scheme
-   *
-   * @param message - The original message
-   * @param signature - The signature to verify
-   * @param keyPublic - The public key
-   * @param options - Optional parameters including scheme
-   * @returns Whether the signature is valid
-   */
-  function verifyMessage(
+  override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
     options?: KeyOptions,
   ): boolean {
-    // Extract scheme from options or use default 'ed25519'
-    const scheme = options?.scheme || "ed25519";
-
-    if (scheme.toLowerCase() === "secp256k1") {
-      return evmVerifyMessage(message, signature, keyPublic, options);
-    }
-
-    // Default to Ed25519
-    return ed25519VerifyMessage(message, signature, keyPublic, options);
+    const scheme = options?.scheme ?? "ed25519";
+    return scheme.toLowerCase() === "secp256k1"
+      ? evmVerifyMessage(message, signature, keyPublic, options)
+      : ed25519VerifyMessage(message, signature, keyPublic, options);
   }
-
-  return {
-    name,
-    curve,
-    network,
-    bip44,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-    signMessage,
-    verifyMessage,
-  } satisfies BlockchainImplementation;
 }
+
+export default Sui;

--- a/src/blockchains/tron.ts
+++ b/src/blockchains/tron.ts
@@ -1,49 +1,33 @@
-import { generateKeyPublic as getKeyPublic } from "../utils/secp256k1.ts";
-import { hexToBytes } from "@noble/hashes/utils.js";
-import { keccak_256 } from "@noble/hashes/sha3.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+import { hexToBytes } from "@noble/hashes/utils.js";
+import { AbstractBlockchain } from "../blockchain.ts";
 import { addSchemeByte } from "../utils/address.ts";
 import { encodeBase58Check, validateBase58Check } from "../utils/encoding.ts";
 import { evmSignMessage, evmVerifyMessage } from "../utils/evm.ts";
-import type { Curve, Options, BlockchainImplementation, KeyOptions } from "../types.ts";
+import { generateKeyPublic } from "../utils/secp256k1.ts";
+import type { Curve, KeyOptions } from "../types.ts";
 
-/**
- * Tron blockchain implementation
- *
- * @param options - Optional configuration parameters
- * @param options.network - Network to use (mainnet, testnet, etc.)
- * @returns An object implementing the Blockchain interface for Tron
- */
-export default function tron(options?: Options) {
-  const name = "tron";
-  const curve: Curve = "secp256k1";
-  const network = options?.network || "mainnet";
-  const bip44 = 195; // SLIP-0044 index for TRON
+const NETWORK_PARAMS = {
+  mainnet: { prefixByte: 0x41, prefixChar: "T" },
+  testnet: { prefixByte: 0xa0, prefixChar: "A" },
+} as const;
 
-  const networkParams = {
-    mainnet: {
-      prefixByte: 0x41, // 65 in decimal, mainnet addresses start with 'T'
-      prefixChar: "T",
-    },
-    testnet: {
-      prefixByte: 0xa0, // 160 in decimal, testnet addresses typically start with a different character
-      prefixChar: "A", // Testnet addresses often start with 'A'
-    },
-  };
+/** TRON blockchain implementation. */
+export class Tron extends AbstractBlockchain {
+  override readonly name = "tron";
+  override readonly curve: Curve = "secp256k1";
+  override readonly bip44 = 195;
 
-  // Get parameters for the current network
-  const params = network === "testnet" ? networkParams.testnet : networkParams.mainnet;
+  private get params() {
+    return this.network === "testnet" ? NETWORK_PARAMS.testnet : NETWORK_PARAMS.mainnet;
+  }
 
-  /**
-   * Get TRON address from public key
-   * TRON uses Keccak-256 hash and base58check encoding with version byte
-   * Mainnet addresses start with 'T' (prefix 0x41)
-   * Testnet addresses typically start with 'A' (prefix 0xa0)
-   *
-   * @param keyPublic - The public key as a hex string
-   * @returns TRON address string
-   */
-  function getAddress(keyPublic: string): string {
+  override getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
+    return generateKeyPublic(keyPrivate, options);
+  }
+
+  override getAddress(keyPublic: string): string {
     const keyPublicBytes = hexToBytes(keyPublic);
     let keyBytesForHashing: Uint8Array;
 
@@ -55,39 +39,15 @@ export default function tron(options?: Options) {
       throw new Error(`Invalid public key length: ${keyPublicBytes.length} bytes`);
     }
 
-    const keccakHash = keccak_256(keyBytesForHashing);
-    const addressBytes = keccakHash.slice(-20);
-
-    // Create versioned hash with network-specific prefix byte
-    const hashVersioned = addSchemeByte(addressBytes, params.prefixByte, true);
-
-    // Encode with Base58Check
-    return encodeBase58Check(hashVersioned);
+    const addressBytes = keccak_256(keyBytesForHashing).slice(-20);
+    return encodeBase58Check(addSchemeByte(addressBytes, this.params.prefixByte, true));
   }
 
-  /**
-   * Validate a TRON address
-   * Valid TRON addresses:
-   * - Start with the correct prefix character for the network
-   * - Have the correct version byte for the network
-   * - Pass base58check validation
-   *
-   * @param address - The address to validate
-   * @returns Whether the address is valid
-   */
-  function validateAddress(address: string): boolean {
-    return validateBase58Check(address, params.prefixByte, params.prefixChar);
+  override validateAddress(address: string): boolean {
+    return validateBase58Check(address, this.params.prefixByte, this.params.prefixChar);
   }
 
-  /**
-   * Signs a message using secp256k1 for TRON
-   *
-   * @param message - The message to sign
-   * @param keyPrivate - The private key
-   * @param options - Optional parameters
-   * @returns The signature as a hex string
-   */
-  function signMessage(
+  override signMessage(
     message: string | Uint8Array,
     keyPrivate: string,
     options?: KeyOptions,
@@ -95,16 +55,7 @@ export default function tron(options?: Options) {
     return evmSignMessage(message, keyPrivate, options);
   }
 
-  /**
-   * Verifies a message signature for TRON
-   *
-   * @param message - The original message
-   * @param signature - The signature to verify
-   * @param keyPublic - The public key
-   * @param options - Optional parameters
-   * @returns Whether the signature is valid
-   */
-  function verifyMessage(
+  override verifyMessage(
     message: string | Uint8Array,
     signature: string,
     keyPublic: string,
@@ -112,16 +63,6 @@ export default function tron(options?: Options) {
   ): boolean {
     return evmVerifyMessage(message, signature, keyPublic, options);
   }
-
-  return {
-    name,
-    curve,
-    network,
-    bip44,
-    getKeyPublic,
-    getAddress,
-    validateAddress,
-    signMessage,
-    verifyMessage,
-  } satisfies BlockchainImplementation;
 }
+
+export default Tron;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { useBlockchain } from "./blockchain.ts";
+export { AbstractBlockchain, useBlockchain } from "./blockchain.ts";
+export { AbstractEVMBlockchain } from "./utils/evm.ts";
 
 // Export lazy-loaded blockchain implementations
 export { blockchains } from "./_blockchains.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,12 @@ export { signMessage, verifyMessage, type SigningOptions } from "./utils/signing
 
 export type {
   Blockchain,
+  Curve,
   BlockchainImplementation,
   Keys,
   Wallet,
   KeyOptions,
+  Options,
   AddressType,
   NetworkType,
   AddressFormat,

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export interface BlockchainImplementation {
    * The cryptographic curve(s) used by the blockchain.
    * Some blockchains (like SUI) support multiple curves.
    */
-  curve: Curve | Curve[];
+  curve: Curve | readonly Curve[];
 
   /**
    * The network type (mainnet, testnet, etc.).

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -8,16 +8,16 @@ Shared cryptographic primitives and encoding utilities. Everything here is inter
 
 **Plain files** (imported directly by blockchains):
 
-| File                | Lines | Used By                       | Purpose                                                                             |
-| ------------------- | ----- | ----------------------------- | ----------------------------------------------------------------------------------- |
-| `address.ts`        | 312   | bitcoin, sui, aptos, tron     | hash160, legacy/P2SH/SegWit address gen + validation, hex address validation        |
-| `evm.ts`            | 199   | ethereum, base, bitcoin, tron | EVM address gen, EIP-55 checksum, preamble signing, `createEVMBlockchain()` factory |
-| `signing.ts`        | 109   | evm.ts, ed25519-chains.ts     | Generic sign/verify dispatching by curve type                                       |
-| `ed25519-chains.ts` | ~100  | solana, aptos, cardano, sui   | Ed25519 signing variants (raw, Solana-specific)                                     |
-| `secp256k1.ts`      | ~100  | bitcoin, tron, sui, evm.ts    | Public key generation (compressed/uncompressed)                                     |
-| `ed25519.ts`        | ~50   | solana, aptos, cardano, sui   | Ed25519 public key generation                                                       |
-| `encoding.ts`       | ~60   | address.ts, tron              | Base58Check encode/decode/validate                                                  |
-| `crypto-hash.ts`    | ~70   | (internal)                    | Hash function wrappers                                                              |
+| File                | Lines | Used By                          | Purpose                                                                            |
+| ------------------- | ----- | -------------------------------- | ---------------------------------------------------------------------------------- |
+| `address.ts`        | 312   | bitcoin, sui, aptos, tron        | hash160, legacy/P2SH/SegWit address gen + validation, hex address validation       |
+| `evm.ts`            | ~220  | EVM classes and secp256k1 chains | EVM address generation, EIP-55 checksum, preamble signing, `AbstractEVMBlockchain` |
+| `signing.ts`        | ~100  | evm.ts, ed25519-chains.ts        | Generic sign/verify dispatching by curve type                                      |
+| `ed25519-chains.ts` | ~50   | solana, aptos, cardano, sui      | Shared raw Ed25519 signing and verification                                        |
+| `secp256k1.ts`      | ~100  | bitcoin, tron, sui, evm.ts       | Public key generation (compressed/uncompressed)                                    |
+| `ed25519.ts`        | ~50   | solana, aptos, cardano, sui      | Ed25519 public key generation                                                      |
+| `encoding.ts`       | ~60   | address.ts, tron                 | Base58Check encode/decode/validate                                                 |
+| `crypto-hash.ts`    | ~70   | (internal)                       | Hash function wrappers                                                             |
 
 **Subdirectories** (each has `index.ts`):
 
@@ -53,5 +53,5 @@ bip44/ → bip32/ (imports HARDENED_OFFSET, formatIndex)
 ## HOTSPOTS
 
 - **`address.ts`** (312 lines) - most complex file. Handles legacy P2PKH, P2SH, SegWit v0 (bech32), SegWit v1/Taproot (bech32m), P2WSH, and hex address validation. Touch carefully.
-- **`evm.ts`** (199 lines) - EVM address gen + EIP-55 checksum + preamble signing + the `createEVMBlockchain()` factory that 2 chains depend on.
+- **`evm.ts`** (~220 lines) - EVM address generation, EIP-55 checksum, preamble signing, and the `AbstractEVMBlockchain` base used by Ethereum and Base.
 - **`createVersionedHash`** in address.ts is **deprecated** - use `addSchemeByte` instead.

--- a/src/utils/ed25519-chains.ts
+++ b/src/utils/ed25519-chains.ts
@@ -1,5 +1,3 @@
-import { ed25519 } from "@noble/curves/ed25519.js";
-import { hexToBytes, bytesToHex } from "@noble/hashes/utils.js";
 import { signMessage, verifyMessage } from "./signing.ts";
 import type { KeyOptions } from "../types.ts";
 
@@ -44,50 +42,4 @@ export function ed25519VerifyMessage(
     curve: "ed25519",
     ...options,
   });
-}
-
-/**
- * Signs a message using native Ed25519 for Solana
- * This method creates Solana-compatible signatures for explorers
- *
- * @param message - The message to sign
- * @param keyPrivate - The private key
- * @returns The signature as a hex string
- */
-export function solanaSignMessage(message: string | Uint8Array, keyPrivate: string): string {
-  // Convert message to Uint8Array if it's a string
-  const messageBytes = typeof message === "string" ? new TextEncoder().encode(message) : message;
-
-  // Convert private key from hex string to Uint8Array
-  const keyPrivateBytes = hexToBytes(keyPrivate);
-
-  // For Solana, we sign the raw message without any preamble or hashing
-  const signature = ed25519.sign(messageBytes, keyPrivateBytes);
-
-  // Return hex string
-  return bytesToHex(signature);
-}
-
-/**
- * Verifies a Solana signature
- *
- * @param message - The original message
- * @param signature - The signature to verify
- * @param keyPublic - The public key
- * @returns Whether the signature is valid
- */
-export function solanaVerifyMessage(
-  message: string | Uint8Array,
-  signature: string,
-  keyPublic: string,
-): boolean {
-  // Convert message to Uint8Array if it's a string
-  const messageBytes = typeof message === "string" ? new TextEncoder().encode(message) : message;
-
-  // Convert signature and public key from hex strings to Uint8Array
-  const signatureBytes = hexToBytes(signature);
-  const keyPublicBytes = hexToBytes(keyPublic);
-
-  // Verify the signature
-  return ed25519.verify(signatureBytes, messageBytes, keyPublicBytes);
 }

--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -1,9 +1,10 @@
 import { hexToBytes, bytesToHex } from "@noble/hashes/utils.js";
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { AbstractBlockchain } from "../blockchain.ts";
 import { generateKeyPublic as getSecp256k1KeyPublic } from "./secp256k1.ts";
 import { signMessage, verifyMessage } from "./signing.ts";
-import type { BlockchainImplementation, KeyOptions } from "../types.ts";
+import type { KeyOptions } from "../types.ts";
 
 /**
  * Generate an EVM compatible address from a public key
@@ -185,28 +186,37 @@ export function evmVerifyMessage(
 }
 
 /**
- * Factory function that creates a blockchain implementation for an EVM chain
- *
- * @param name - The name of the blockchain
- * @param options - Optional configuration parameters
- * @returns An object implementing the Blockchain interface for EVM chains
+ * Shared implementation for EVM-compatible blockchains.
  */
-export function createEVMBlockchain(
-  name: string,
-  options: { network?: string; bip44: number },
-): BlockchainImplementation {
-  const network = options.network || "mainnet";
-  const bip44 = options.bip44;
+export abstract class AbstractEVMBlockchain extends AbstractBlockchain {
+  override readonly curve = "secp256k1";
 
-  return {
-    name,
-    curve: "secp256k1" as const,
-    network,
-    bip44,
-    getKeyPublic: getSecp256k1KeyPublic,
-    getAddress: generateAddress,
-    validateAddress,
-    signMessage: evmSignMessage,
-    verifyMessage: evmVerifyMessage,
-  };
+  override getKeyPublic(keyPrivate: string, options?: KeyOptions): string {
+    return getSecp256k1KeyPublic(keyPrivate, options);
+  }
+
+  override getAddress(keyPublic: string): string {
+    return generateAddress(keyPublic);
+  }
+
+  override validateAddress(address: string): boolean {
+    return validateAddress(address);
+  }
+
+  override signMessage(
+    message: string | Uint8Array,
+    keyPrivate: string,
+    options?: KeyOptions,
+  ): string {
+    return evmSignMessage(message, keyPrivate, options);
+  }
+
+  override verifyMessage(
+    message: string | Uint8Array,
+    signature: string,
+    keyPublic: string,
+    options?: KeyOptions,
+  ): boolean {
+    return evmVerifyMessage(message, signature, keyPublic, options);
+  }
 }

--- a/test/blockchains/aptos.test.ts
+++ b/test/blockchains/aptos.test.ts
@@ -1,11 +1,11 @@
 import { expect, describe, it } from "vitest";
-import aptos from "../../src/blockchains/aptos";
+import Aptos from "../../src/blockchains/aptos";
 import { useBlockchain } from "../../src/blockchain";
 import type { Options } from "../../src/types";
 
 describe("Aptos Blockchain", () => {
   describe("Mainnet", () => {
-    const blockchain = useBlockchain(aptos());
+    const blockchain = useBlockchain(new Aptos());
 
     // Test private key generation
     it("generates a valid private key", () => {
@@ -55,7 +55,7 @@ describe("Aptos Blockchain", () => {
 
   describe("Testnet", () => {
     const options: Options = { network: "testnet" };
-    const testnetBlockchain = useBlockchain(aptos(options));
+    const testnetBlockchain = useBlockchain(new Aptos(options));
 
     describe("blockchain interface", () => {
       it("has correct name", () => {
@@ -74,7 +74,7 @@ describe("Aptos Blockchain", () => {
     describe("address generation", () => {
       it("generates identical addresses for testnet and mainnet", () => {
         // Aptos uses the same address format for both networks
-        const mainnetBlockchain = useBlockchain(aptos());
+        const mainnetBlockchain = useBlockchain(new Aptos());
         const keyPrivate = "0000000000000000000000000000000000000000000000000000000000000001";
 
         const testnetPublicKey = testnetBlockchain.getKeyPublic(keyPrivate);

--- a/test/blockchains/base.test.ts
+++ b/test/blockchains/base.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { useBlockchain } from "../../src";
-import base from "../../src/blockchains/base";
+import Base from "../../src/blockchains/base";
 
 describe("Base blockchain", () => {
-  const blockchain = useBlockchain(base());
+  const blockchain = useBlockchain(new Base());
 
   it("should have a name", () => {
     expect(blockchain.name).toBe("base");

--- a/test/blockchains/bitcoin.test.ts
+++ b/test/blockchains/bitcoin.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { useBlockchain } from "../../src";
-import bitcoin from "../../src/blockchains/bitcoin";
+import Bitcoin from "../../src/blockchains/bitcoin";
 import type { Options } from "../../src/types";
 
 describe("Bitcoin blockchain", () => {
-  const blockchain = useBlockchain(bitcoin());
+  const blockchain = useBlockchain(new Bitcoin());
 
   it("should have a name", () => {
     expect(blockchain.name).toBe("bitcoin");
@@ -262,8 +262,8 @@ describe("Bitcoin blockchain", () => {
     });
 
     it("should produce different signatures than EVM for the same key and message", async () => {
-      const { default: ethereum } = await import("../../src/blockchains/ethereum");
-      const ethBlockchain = useBlockchain(ethereum());
+      const { default: Ethereum } = await import("../../src/blockchains/ethereum");
+      const ethBlockchain = useBlockchain(new Ethereum());
 
       const wallet = blockchain.generateWallet();
       const message = "Test message";
@@ -278,7 +278,7 @@ describe("Bitcoin blockchain", () => {
   describe("Testnet addresses", () => {
     // Create bitcoin blockchain with testnet network option
     const options: Options = { network: "testnet" };
-    const testnetBlockchain = useBlockchain(bitcoin(options));
+    const testnetBlockchain = useBlockchain(new Bitcoin(options));
 
     it("should have a network property set to testnet", () => {
       expect(testnetBlockchain.network).toBe("testnet");

--- a/test/blockchains/cardano.test.ts
+++ b/test/blockchains/cardano.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { useBlockchain } from "../../src/blockchain";
-import cardano from "../../src/blockchains/cardano";
+import Cardano from "../../src/blockchains/cardano";
 import type { Options } from "../../src/types";
 
 describe("Cardano blockchain", () => {
   describe("Mainnet", () => {
-    const blockchain = useBlockchain(cardano());
+    const blockchain = useBlockchain(new Cardano());
 
     // Ensure validateAddress is defined for TypeScript
     const validateAddress = (address: string): boolean => {
@@ -162,7 +162,7 @@ describe("Cardano blockchain", () => {
 
   describe("Testnet", () => {
     const options: Options = { network: "testnet" };
-    const testnetBlockchain = useBlockchain(cardano(options));
+    const testnetBlockchain = useBlockchain(new Cardano(options));
 
     // Ensure validateAddress is defined for TypeScript
     const validateAddress = (address: string): boolean => {

--- a/test/blockchains/ethereum.test.ts
+++ b/test/blockchains/ethereum.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { useBlockchain } from "../../src";
-import ethereum from "../../src/blockchains/ethereum";
+import Ethereum from "../../src/blockchains/ethereum";
 import type { Options } from "../../src/types";
 
 describe("Ethereum blockchain", () => {
   describe("Mainnet", () => {
-    const blockchain = useBlockchain(ethereum());
+    const blockchain = useBlockchain(new Ethereum());
 
     it("should have a name", () => {
       expect(blockchain.name).toBe("ethereum");
@@ -144,7 +144,7 @@ describe("Ethereum blockchain", () => {
 
   describe("Testnet", () => {
     const options: Options = { network: "testnet" };
-    const testnetBlockchain = useBlockchain(ethereum(options));
+    const testnetBlockchain = useBlockchain(new Ethereum(options));
 
     it("should have a name", () => {
       expect(testnetBlockchain.name).toBe("ethereum");
@@ -161,7 +161,7 @@ describe("Ethereum blockchain", () => {
     describe("Address generation", () => {
       it("should generate the same addresses for both networks", () => {
         // EVM addresses are the same regardless of network
-        const mainnetBlockchain = useBlockchain(ethereum());
+        const mainnetBlockchain = useBlockchain(new Ethereum());
         const keyPrivate = "0000000000000000000000000000000000000000000000000000000000000001";
 
         const testnetPublicKey = testnetBlockchain.getKeyPublic(keyPrivate);

--- a/test/blockchains/solana.test.ts
+++ b/test/blockchains/solana.test.ts
@@ -49,6 +49,13 @@ describe("Solana Blockchain", () => {
       expect(blockchain.validateAddress?.("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2")).toBe(false); // Bitcoin address
       expect(blockchain.validateAddress?.("")).toBe(false);
     });
+
+    it("returns false for malformed signatures", () => {
+      const keyPrivate = "0000000000000000000000000000000000000000000000000000000000000001";
+      const keyPublic = blockchain.getKeyPublic(keyPrivate);
+
+      expect(blockchain.verifyMessage("message", "not-a-signature", keyPublic)).toBe(false);
+    });
   });
 
   describe("Testnet", () => {

--- a/test/blockchains/solana.test.ts
+++ b/test/blockchains/solana.test.ts
@@ -1,11 +1,11 @@
 import { expect, describe, it } from "vitest";
-import solana from "../../src/blockchains/solana";
+import Solana from "../../src/blockchains/solana";
 import { useBlockchain } from "../../src/blockchain";
 import type { Options } from "../../src/types";
 
 describe("Solana Blockchain", () => {
   describe("Mainnet", () => {
-    const blockchain = useBlockchain(solana());
+    const blockchain = useBlockchain(new Solana());
 
     // Test private key generation
     it("generates a valid private key", () => {
@@ -53,7 +53,7 @@ describe("Solana Blockchain", () => {
 
   describe("Testnet", () => {
     const options: Options = { network: "testnet" };
-    const testnetBlockchain = useBlockchain(solana(options));
+    const testnetBlockchain = useBlockchain(new Solana(options));
 
     describe("blockchain interface", () => {
       it("has correct name", () => {
@@ -72,7 +72,7 @@ describe("Solana Blockchain", () => {
     describe("address generation", () => {
       it("generates identical addresses for testnet and mainnet", () => {
         // Solana uses the same address format for both networks
-        const mainnetBlockchain = useBlockchain(solana());
+        const mainnetBlockchain = useBlockchain(new Solana());
         const keyPrivate = "0000000000000000000000000000000000000000000000000000000000000001";
 
         const testnetPublicKey = testnetBlockchain.getKeyPublic(keyPrivate);

--- a/test/blockchains/sui.test.ts
+++ b/test/blockchains/sui.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import sui from "../../src/blockchains/sui";
+import Sui from "../../src/blockchains/sui";
 import { useBlockchain } from "../../src/blockchain";
 import type { Options } from "../../src/types";
 
 describe("Sui", () => {
   describe("Mainnet", () => {
-    const blockchain = useBlockchain(sui());
+    const blockchain = useBlockchain(new Sui());
 
     // Test vectors
     const keyPrivate = "0000000000000000000000000000000000000000000000000000000000000001";
@@ -73,7 +73,7 @@ describe("Sui", () => {
 
   describe("Testnet", () => {
     const options: Options = { network: "testnet" };
-    const testnetBlockchain = useBlockchain(sui(options));
+    const testnetBlockchain = useBlockchain(new Sui(options));
 
     describe("blockchain interface", () => {
       it("has correct name", () => {

--- a/test/blockchains/sui.test.ts
+++ b/test/blockchains/sui.test.ts
@@ -40,6 +40,13 @@ describe("Sui", () => {
       });
     });
 
+    it("uses the key scheme when generating a wallet address", () => {
+      const wallet = blockchain.generateWallet({ scheme: "secp256k1" });
+
+      expect(wallet.address).toBe(blockchain.getAddress(wallet.keys.public, "secp256k1"));
+      expect(wallet.address).not.toBe(blockchain.getAddress(wallet.keys.public, "ed25519"));
+    });
+
     describe("Address validation", () => {
       it("should validate correct Sui addresses", () => {
         expect(blockchain.validateAddress?.(addressEd25519)).toBe(true);

--- a/test/blockchains/tron.test.ts
+++ b/test/blockchains/tron.test.ts
@@ -1,9 +1,9 @@
 import { expect, describe, it } from "vitest";
-import tron from "../../src/blockchains/tron";
+import Tron from "../../src/blockchains/tron";
 import { useBlockchain } from "../../src/blockchain";
 
 describe("TRON Blockchain", () => {
-  const blockchain = useBlockchain(tron());
+  const blockchain = useBlockchain(new Tron());
 
   describe("Key Generation", () => {
     // Test vectors for key pairs with correct values from our test

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { useBlockchain } from "../src";
-import bitcoin from "../src/blockchains/bitcoin";
-import ethereum from "../src/blockchains/ethereum";
+import { AbstractBlockchain, AbstractEVMBlockchain, blockchains, useBlockchain } from "../src";
+import Bitcoin, { Bitcoin as BitcoinClass } from "../src/blockchains/bitcoin";
+import Ethereum from "../src/blockchains/ethereum";
+
+describe("Blockchain class API", () => {
+  it("exports the concrete class as both the named and default export", () => {
+    expect(Bitcoin).toBe(BitcoinClass);
+    expect(new Bitcoin()).toBeInstanceOf(AbstractBlockchain);
+    expect(new Ethereum()).toBeInstanceOf(AbstractEVMBlockchain);
+  });
+
+  it("constructs concrete classes through the lazy registry", async () => {
+    const blockchain = await blockchains.bitcoin({ network: "testnet" })();
+
+    expect(blockchain).toBeInstanceOf(Bitcoin);
+    expect(blockchain.network).toBe("testnet");
+    expect(useBlockchain(blockchain)).toBe(blockchain);
+  });
+
+  it("preserves mainnet defaulting for empty network values", async () => {
+    const blockchain = await blockchains.bitcoin({ network: "" })();
+
+    expect(blockchain.network).toBe("mainnet");
+  });
+});
 
 describe("Common blockchain functionality", () => {
   it("should expose useBlockchain function", () => {
@@ -10,7 +32,7 @@ describe("Common blockchain functionality", () => {
 
   describe("generateKeys function", () => {
     it("should generate a valid key pair for Bitcoin", () => {
-      const blockchain = useBlockchain(bitcoin());
+      const blockchain = useBlockchain(new Bitcoin());
       const keys = blockchain.generateKeys();
 
       // Verify structure
@@ -31,7 +53,7 @@ describe("Common blockchain functionality", () => {
     });
 
     it("should generate a valid key pair for Ethereum", () => {
-      const blockchain = useBlockchain(ethereum());
+      const blockchain = useBlockchain(new Ethereum());
       const keys = blockchain.generateKeys();
 
       // Verify structure
@@ -52,7 +74,7 @@ describe("Common blockchain functionality", () => {
     });
 
     it("should respect options passed to generateKeys", () => {
-      const blockchain = useBlockchain(bitcoin());
+      const blockchain = useBlockchain(new Bitcoin());
 
       // Generate with default options (compressed key)
       const compressedKeys = blockchain.generateKeys();
@@ -68,7 +90,7 @@ describe("Common blockchain functionality", () => {
     });
 
     it("should generate different key pairs each time", () => {
-      const blockchain = useBlockchain(bitcoin());
+      const blockchain = useBlockchain(new Bitcoin());
       const keys1 = blockchain.generateKeys();
       const keys2 = blockchain.generateKeys();
 
@@ -77,7 +99,7 @@ describe("Common blockchain functionality", () => {
     });
 
     it("should generate a valid wallet with address", () => {
-      const blockchain = useBlockchain(bitcoin());
+      const blockchain = useBlockchain(new Bitcoin());
       const wallet = blockchain.generateWallet();
 
       // Verify structure
@@ -101,7 +123,7 @@ describe("Common blockchain functionality", () => {
     });
 
     it("should respect address type in generateWallet", () => {
-      const blockchain = useBlockchain(bitcoin());
+      const blockchain = useBlockchain(new Bitcoin());
 
       // Default legacy address
       const legacyWallet = blockchain.generateWallet();

--- a/test/utils/bip44.test.ts
+++ b/test/utils/bip44.test.ts
@@ -7,9 +7,9 @@ import {
   getBlockchainPath,
 } from "../../src/utils/bip44";
 import { useBlockchain } from "../../src/blockchain";
-import bitcoin from "../../src/blockchains/bitcoin";
-import ethereum from "../../src/blockchains/ethereum";
-import solana from "../../src/blockchains/solana";
+import Bitcoin from "../../src/blockchains/bitcoin";
+import Ethereum from "../../src/blockchains/ethereum";
+import Solana from "../../src/blockchains/solana";
 
 describe("BIP44 Path Generation", () => {
   test("should generate correct BIP44 path for Bitcoin", () => {
@@ -79,25 +79,25 @@ describe("BIP44 Path Parsing", () => {
 
 describe("Blockchain Path Integration", () => {
   test("should generate correct path for bitcoin blockchain", () => {
-    const chain = useBlockchain(bitcoin());
+    const chain = useBlockchain(new Bitcoin());
     const path = getBlockchainPath(chain);
     expect(path).toBe("m/44'/0'/0'/0/0");
   });
 
   test("should generate correct path for ethereum blockchain", () => {
-    const chain = useBlockchain(ethereum());
+    const chain = useBlockchain(new Ethereum());
     const path = getBlockchainPath(chain);
     expect(path).toBe("m/44'/60'/0'/0/0");
   });
 
   test("should generate correct path for solana blockchain", () => {
-    const chain = useBlockchain(solana());
+    const chain = useBlockchain(new Solana());
     const path = getBlockchainPath(chain);
     expect(path).toBe("m/44'/501'/0'/0/0");
   });
 
   test("should respect custom account parameters", () => {
-    const chain = useBlockchain(bitcoin());
+    const chain = useBlockchain(new Bitcoin());
     const path = getBlockchainPath(chain, 2, BIP44Change.INTERNAL, 5);
     expect(path).toBe("m/44'/0'/2'/1/5");
   });

--- a/test/utils/signing-integration.test.ts
+++ b/test/utils/signing-integration.test.ts
@@ -3,8 +3,8 @@ import { Keypair } from "@solana/web3.js";
 import { SigningKey, Wallet } from "ethers";
 import { hexToBytes, bytesToHex } from "@noble/hashes/utils.js";
 import { useBlockchain } from "../../src/blockchain";
-import ethereum from "../../src/blockchains/ethereum";
-import solana from "../../src/blockchains/solana";
+import Ethereum from "../../src/blockchains/ethereum";
+import Solana from "../../src/blockchains/solana";
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { secp256k1TestVectors, testMessages } from "../fixtures";
 
@@ -18,7 +18,7 @@ describe("Signing Integration Tests", () => {
       const solanaPublicKeyHex = bytesToHex(solanaKeypair.publicKey.toBytes());
 
       // Create corresponding keys using ubichain
-      const solanaBlockchain = useBlockchain(solana());
+      const solanaBlockchain = useBlockchain(new Solana());
       const ubichainPublicKey = solanaBlockchain.getKeyPublic(solanaPrivateKeyHex);
 
       // Verify that public keys match
@@ -42,7 +42,7 @@ describe("Signing Integration Tests", () => {
 
     it("should produce valid signatures for Solana", () => {
       // Create new keys in ubichain
-      const solanaBlockchain = useBlockchain(solana());
+      const solanaBlockchain = useBlockchain(new Solana());
       const ubichainWallet = solanaBlockchain.generateWallet();
 
       // Sign message using ubichain
@@ -96,7 +96,7 @@ describe("Signing Integration Tests", () => {
 
       // Create instances of both libraries
       const ethersSigningKey = new SigningKey(privateKeyHex);
-      const ethereumBlockchain = useBlockchain(ethereum());
+      const ethereumBlockchain = useBlockchain(new Ethereum());
 
       // Get public keys
       const ethersPublicKey = ethersSigningKey.publicKey.slice(2); // remove '0x' prefix
@@ -120,7 +120,7 @@ describe("Signing Integration Tests", () => {
       const privateKeyNoPrefix = privateKeyHex.slice(2);
 
       // Create Ethereum instance and derive keys from the same private key
-      const ethereumBlockchain = useBlockchain(ethereum());
+      const ethereumBlockchain = useBlockchain(new Ethereum());
       const publicKey = ethereumBlockchain.getKeyPublic(privateKeyNoPrefix, { compressed: false });
       const ubichainAddress = ethereumBlockchain.getAddress(publicKey);
 


### PR DESCRIPTION
I'm moving my libraries to class-based architecture step by step, ubichain is one of these refactors. I simply read classes easier, everything feels cleaner, clearer and more organized to me. Replaced chain factories with `AbstractBlockchain`, `AbstractEVMBlockchain` and normal classes for all chains. Lazy registry stays as it was, direct imports need `new`, so yes, this is breaking.

`pnpm test` passes, 194 tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/ubichain/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blockchain integrations now use class-based constructors for Bitcoin, Ethereum, Solana, Aptos, Cardano, Sui, TRON, and Base.
  * Added reusable abstract blockchain classes for custom integrations.
  * Lazy-loaded blockchains are instantiated after the second call.
  * Expanded exports for blockchain base classes.

* **Documentation**
  * Clarified lazy-loading behavior in the Usage documentation.

* **Tests**
  * Updated integration and blockchain tests for class-based initialization and lazy-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->