### PR TITLE
fix: generate valid secp256k1 private keys

### DIFF
--- a/src/blockchain.ts
+++ b/src/blockchain.ts
@@ -1,4 +1,5 @@
 import { webcrypto } from "node:crypto";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { bytesToHex } from "@noble/hashes/utils.js";
 import type { AddressType, Blockchain, Curve, KeyOptions, Keys, Options, Wallet } from "./types.ts";
 
@@ -32,7 +33,10 @@ export abstract class AbstractBlockchain implements Blockchain {
   ): boolean;
 
   generateKeyPrivate(): string {
-    const keyPrivateBytes = webcrypto.getRandomValues(new Uint8Array(32));
+    const keyPrivateBytes = this.curve.includes("secp256k1")
+      ? secp256k1.utils.randomSecretKey()
+      : webcrypto.getRandomValues(new Uint8Array(32));
+
     return bytesToHex(keyPrivateBytes);
   }
 

--- a/test/blockchains/bitcoin.test.ts
+++ b/test/blockchains/bitcoin.test.ts
@@ -1,6 +1,6 @@
 import { webcrypto } from "node:crypto";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
-import { hexToBytes } from "@noble/hashes/utils.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
 import { describe, expect, it, vi } from "vitest";
 import { useBlockchain } from "../../src";
 import Bitcoin from "../../src/blockchains/bitcoin";
@@ -20,19 +20,20 @@ describe("Bitcoin blockchain", () => {
     expect(keyPrivate).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it("should generate only valid secp256k1 private keys", () => {
-    const randomValues = [0, 0xff, 1];
-    let attempt = 0;
+  it("should generate a private key from a 48-byte secp256k1 seed", () => {
+    const seed = new Uint8Array(48);
     const getRandomValues = vi.spyOn(webcrypto, "getRandomValues").mockImplementation((array) => {
       const bytes = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
-      bytes.fill(randomValues[attempt] ?? 1);
-      attempt += 1;
+      bytes.set(seed.subarray(0, bytes.byteLength));
       return array;
     });
 
     try {
-      const keyPrivate = hexToBytes(blockchain.generateKeyPrivate());
-      expect(secp256k1.utils.isValidSecretKey(keyPrivate)).toBe(true);
+      const keyPrivate = blockchain.generateKeyPrivate();
+
+      expect(getRandomValues).toHaveBeenCalledOnce();
+      expect(getRandomValues.mock.calls[0]?.[0].byteLength).toBe(seed.byteLength);
+      expect(keyPrivate).toBe(bytesToHex(secp256k1.utils.randomSecretKey(seed)));
     } finally {
       getRandomValues.mockRestore();
     }

--- a/test/blockchains/bitcoin.test.ts
+++ b/test/blockchains/bitcoin.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { webcrypto } from "node:crypto";
+import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { hexToBytes } from "@noble/hashes/utils.js";
+import { describe, expect, it, vi } from "vitest";
 import { useBlockchain } from "../../src";
 import Bitcoin from "../../src/blockchains/bitcoin";
 import type { Options } from "../../src/types";
@@ -15,6 +18,24 @@ describe("Bitcoin blockchain", () => {
 
     // Private key should be a 64-character hex string (32 bytes)
     expect(keyPrivate).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("should generate only valid secp256k1 private keys", () => {
+    const randomValues = [0, 0xff, 1];
+    let attempt = 0;
+    const getRandomValues = vi.spyOn(webcrypto, "getRandomValues").mockImplementation((array) => {
+      const bytes = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+      bytes.fill(randomValues[attempt] ?? 1);
+      attempt += 1;
+      return array;
+    });
+
+    try {
+      const keyPrivate = hexToBytes(blockchain.generateKeyPrivate());
+      expect(secp256k1.utils.isValidSecretKey(keyPrivate)).toBe(true);
+    } finally {
+      getRandomValues.mockRestore();
+    }
   });
 
   it("should generate different private keys each time", () => {


### PR DESCRIPTION
I don't want `generateKeyPrivate()` returning invalid secp256k1 key even if chance is absurdly small. Secp256k1 chains use noble's `randomSecretKey()` now, ed25519 stays unchanged. Closes #9.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/ubichain/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

