### PR TITLE
fix: type SLIP-10 HD keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint": "oxlint . && oxfmt --check .",
     "lint:fix": "oxlint . --fix && oxfmt .",
     "test": "pnpm lint && pnpm test:types && pnpm build && pnpm test:ext && vitest run --coverage",
-    "test:types": "tsc --noEmit --skipLibCheck",
+    "test:types": "tsc --noEmit --skipLibCheck && tsc -p tsconfig.type-tests.json --noEmit --skipLibCheck",
     "test:ext": "tsc -p tsconfig.extensions.json --noEmit",
     "playground": "tsx",
     "playground:bip32": "tsx playground/bip32-demo.ts",

--- a/src/utils/slip10/index.ts
+++ b/src/utils/slip10/index.ts
@@ -1,8 +1,7 @@
-import slip10 from "micro-key-producer/slip10.js";
+import { HDKey } from "micro-key-producer/slip10.js";
 
 // Reexport the SLIP10 implementation
-const HDKeyImpl = slip10;
-export { HDKeyImpl as HDKey };
+export { HDKey };
 
 // SLIP-0010 hardened offset constant - same as BIP32
 export const HARDENED_OFFSET = 0x80_00_00_00;
@@ -12,8 +11,8 @@ export const HARDENED_OFFSET = 0x80_00_00_00;
  * @param seed - A seed byte array
  * @returns HDKey instance for the master key
  */
-export function getMasterKeyFromSeed(seed: Uint8Array): any {
-  return slip10.fromMasterSeed(seed);
+export function getMasterKeyFromSeed(seed: Uint8Array): HDKey {
+  return HDKey.fromMasterSeed(seed);
 }
 
 /**
@@ -23,7 +22,7 @@ export function getMasterKeyFromSeed(seed: Uint8Array): any {
  * @param forceHardened - Whether to force hardened derivation for ed25519
  * @returns Derived HDKey instance
  */
-export function deriveHDKey(parent: any, path: string, forceHardened = true): any {
+export function deriveHDKey(parent: HDKey, path: string, forceHardened = true): HDKey {
   return parent.derive(path, forceHardened);
 }
 
@@ -33,7 +32,7 @@ export function deriveHDKey(parent: any, path: string, forceHardened = true): an
  * @param index - Child index (use index + HARDENED_OFFSET for hardened keys)
  * @returns Derived HDKey child
  */
-export function deriveHDChild(parent: any, index: number): any {
+export function deriveHDChild(parent: HDKey, index: number): HDKey {
   return parent.deriveChild(index);
 }
 

--- a/test/utils/slip10.test.ts
+++ b/test/utils/slip10.test.ts
@@ -16,7 +16,9 @@ describe("SLIP-0010 Utils", () => {
 
   it("creates a master key from seed", () => {
     const masterKey = getMasterKeyFromSeed(testSeed);
-    expect(Buffer.from(masterKey.privateKey).toString("hex")).toBe(
+    const privateKey: Uint8Array = masterKey.privateKey;
+    const derivedKey: typeof masterKey = masterKey.derive("m/0'");
+    expect(Buffer.from(privateKey).toString("hex")).toBe(
       "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7",
     );
     expect(Buffer.from(masterKey.publicKey).toString("hex")).toBe(
@@ -25,6 +27,9 @@ describe("SLIP-0010 Utils", () => {
     expect(Buffer.from(masterKey.chainCode).toString("hex")).toBe(
       "90046a93de5380a72b5e45010748567d5ea02bbf6522f979e05c0d8d8ca9fffb",
     );
+    expect(derivedKey.privateKey).toBeInstanceOf(Uint8Array);
+    // @ts-expect-error SLIP-10 keys must reject unknown properties.
+    expect(masterKey.privKey).toBeUndefined();
   });
 
   it("derives child keys using path", () => {

--- a/tsconfig.type-tests.json
+++ b/tsconfig.type-tests.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["test/utils/slip10.test.ts"]
+}


### PR DESCRIPTION
`any` on every SLIP-10 helper made TypeScript basically useless there - even `.privKey` looked valid. They use `micro-key-producer`'s real `HDKey` now, plus compile-time regression check so this doesn't sneak back. Closes #10.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/ubichain/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

